### PR TITLE
(fix): Hint always has a dom element, resulting in hint methods not being noop

### DIFF
--- a/src/autocomplete/typeahead.js
+++ b/src/autocomplete/typeahead.js
@@ -589,7 +589,8 @@ function buildDom(options) {
   return {
     wrapper: $wrapper,
     input: $input,
-    hint: $hint,
+    // hint needs to be based on wrapper or else it will always exist on input creation
+    hint: $wrapper.find($hint),
     menu: $dropdown
   };
 }

--- a/test/unit/typeahead_spec.js
+++ b/test/unit/typeahead_spec.js
@@ -906,4 +906,28 @@ describe('Typeahead', function() {
       expect(this.$input.attr('aria-label')).toBeUndefined();
     });
   });
+
+  describe('when hint is set', function () {
+    beforeEach(function() {
+      this.view.destroy();
+    });
+
+    it('should return a hint of length 1 if hint is true', function () {
+      this.view = new Typeahead({
+        input: this.$input,
+        hint: true
+      });
+      var $hint = this.view.$node.find('.aa-hint');
+      expect($hint.length).toBe(1);
+    });
+
+    it('should return a hint of length 0 if hint is false', function () {
+      this.view = new Typeahead({
+        input: this.$input,
+        hint: false
+      });
+      var $hint = this.view.$node.find('.aa-hint');
+      expect($hint.length).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
**Summary**
This fix is to correctly pass in the `$hint` jQuery object to the Typeahead Input.

This issue here is that in typeahead.js, there is a hint option that is used to either append or not to append the hint element. The hint element is created regardless of whether the option `hint` is `true`, resulting in the element to always have a length of 1. This causes an error [here](https://github.com/algolia/autocomplete.js/blob/master/src/autocomplete/input.js#L48). Because hint is always being passed back as a valid jQuery object, it never hits inside that `if`.

This issue arose when we were tabbing through with `{ hint: false, openOnFocus: true, autoselect: false, minLength: 0 }` It seems that the hint element does exist, _but_ it is not in the DOM resulting in the selection of the first item.

The proposed change is to pass back the `$hint` jQuery object that is based on the wrapper having it, and not just the base created element.

**Result**
Review test:
If `hint` is false, then the Typeahead.Input should have noop for the hint methods.
if `hint` is true, then the Typeahead.Input should work as is, with no noop functions.

Old Behavior while just using `tab`:
![old-behavior](https://user-images.githubusercontent.com/8492971/37114687-9ff44c14-220e-11e8-9df0-baeda065d085.gif)

Fixed Behavior while just using `tab`:
![fixed-behavior](https://user-images.githubusercontent.com/8492971/37114686-9fe31b9c-220e-11e8-91de-908150e3d69a.gif)
