### PR TITLE
Add min/max length to datasets and update/clear them within the range.

### DIFF
--- a/src/autocomplete/dataset.js
+++ b/src/autocomplete/dataset.js
@@ -37,6 +37,9 @@ function Dataset(o) {
 
   this.templates = getTemplates(o.templates, this.displayFn);
 
+  this.minLength = _.isNumber(o.minLength) ? o.minLength : 1;
+  this.maxLength = _.isNumber(o.maxLength) ? o.maxLength : Number.MAX_VALUE;
+
   this.css = _.mixin({}, css, o.appendTo ? css.appendTo : {});
   this.cssClasses = o.cssClasses = _.mixin({}, css.defaultClasses, o.cssClasses || {});
   this.cssClasses.prefix =

--- a/src/autocomplete/dropdown.js
+++ b/src/autocomplete/dropdown.js
@@ -353,7 +353,11 @@ _.mixin(Dropdown.prototype, EventEmitter, {
     _.each(this.datasets, updateDataset);
 
     function updateDataset(dataset) {
-      dataset.update(query);
+      if (query.length >= dataset.minLength && query.length <= dataset.maxLength) {
+        dataset.update(query);
+      } else {
+        dataset.clear();
+      }
     }
   },
 

--- a/test/unit/dropdown_spec.js
+++ b/test/unit/dropdown_spec.js
@@ -431,9 +431,18 @@ describe('Dropdown', function() {
   });
 
   describe('#update', function() {
-    it('should invoke update on each dataset', function() {
-      this.view.update();
+    it('should invoke update on each dataset that is within the query length', function() {
+      this.dataset.minLength = 1;
+      this.dataset.maxLength = Number.MAX_VALUE;
+      this.view.update('query');
       expect(this.dataset.update).toHaveBeenCalled();
+    });
+
+    it('should invoke clear on each dataset that is not within the query length', function() {
+      this.dataset.minLength = 6;
+      this.dataset.maxLength = Number.MAX_VALUE;
+      this.view.update('query');
+      expect(this.dataset.clear).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
**Summary**

Hi,

I've been looking for a way to have datasets enable and disable themselves based on a min and max length of the query, so that I can have some datasets that appear within the range of certain query lengths.

Proposed change is to take in a minLength and maxLength parameter to datasets and update/empty datasets when they are within/not within the specified ranges.  Normal behavior without the parameters stays the same.

Looks like this should cover #200 also.

**Result**

![2018-04-02 15 43 27](https://user-images.githubusercontent.com/201509/38212694-acee08f0-368c-11e8-944f-db160333c32c.gif)

Here is an example using the playground where actors is set to `minLength: 1`, `maxLength: 2`

