### PR TITLE
test(js): add tests for API and options

### DIFF
--- a/packages/autocomplete-js/src/__tests__/api.test.ts
+++ b/packages/autocomplete-js/src/__tests__/api.test.ts
@@ -1,24 +1,7 @@
-import { fireEvent, waitFor } from '@testing-library/dom';
+import { createAutocomplete } from '@algolia/autocomplete-core';
 
+import { createCollection } from '../../../../test/utils';
 import { autocomplete } from '../autocomplete';
-import {
-  createAutocomplete,
-  AutocompleteCollection,
-} from '@algolia/autocomplete-core';
-
-function createCollection(items) {
-  return {
-    source: {
-      getItemInputValue: ({ item }) => item.label,
-      getItemUrl: () => undefined,
-      onActive: () => {},
-      onSelect: () => {},
-      getItems: () => items,
-      templates: {},
-    },
-    items,
-  };
-}
 
 describe('api', () => {
   describe('setActiveItemId', () => {
@@ -26,7 +9,6 @@ describe('api', () => {
       const onStateChange = jest.fn();
       const container = document.createElement('div');
       const { setActiveItemId } = autocomplete<{ label: string }>({
-        id: 'autocomplete',
         container,
         onStateChange,
       });
@@ -56,7 +38,6 @@ describe('api', () => {
       const onStateChange = jest.fn();
       const container = document.createElement('div');
       const { setQuery } = autocomplete<{ label: string }>({
-        id: 'autocomplete',
         container,
         onStateChange,
       });
@@ -77,12 +58,24 @@ describe('api', () => {
       const onStateChange = jest.fn();
       const container = document.createElement('div');
       const { setCollections } = autocomplete<{ label: string }>({
-        id: 'autocomplete',
         container,
         onStateChange,
       });
 
-      setCollections([createCollection([{ label: 'hi' }])]);
+      const items = [{ label: 'hi' }];
+      const collection = createCollection({
+        source: {
+          getItemInputValue: ({ item }) => item.label,
+          getItemUrl: () => undefined,
+          onActive: () => {},
+          onSelect: () => {},
+          getItems: () => items,
+          templates: {},
+        },
+        items,
+      });
+
+      setCollections([collection]);
 
       expect(onStateChange).toHaveBeenCalledTimes(1);
       expect(onStateChange).toHaveBeenCalledWith(
@@ -111,7 +104,20 @@ describe('api', () => {
         onStateChange,
       });
 
-      setCollections([createCollection([[{ label: 'hi' }]])]);
+      const items = [{ label: 'hi' }];
+      const collection = createCollection({
+        source: {
+          getItemInputValue: ({ item }) => item.label,
+          getItemUrl: () => undefined,
+          onActive: () => {},
+          onSelect: () => {},
+          getItems: () => items,
+          templates: {},
+        },
+        items,
+      });
+
+      setCollections([collection]);
 
       expect(onStateChange).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -132,7 +138,6 @@ describe('api', () => {
       const onStateChange = jest.fn();
       const container = document.createElement('div');
       const { setIsOpen } = autocomplete<{ label: string }>({
-        id: 'autocomplete',
         container,
         onStateChange,
       });
@@ -162,7 +167,6 @@ describe('api', () => {
       const onStateChange = jest.fn();
       const container = document.createElement('div');
       const { setStatus } = autocomplete<{ label: string }>({
-        id: 'autocomplete',
         container,
         onStateChange,
       });
@@ -183,7 +187,6 @@ describe('api', () => {
       const onStateChange = jest.fn();
       const container = document.createElement('div');
       const { setContext } = autocomplete<{ label: string }>({
-        id: 'autocomplete',
         container,
         onStateChange,
       });
@@ -216,7 +219,6 @@ describe('api', () => {
       const container = document.createElement('div');
       document.body.appendChild(container);
       const { update } = autocomplete<{ label: string }>({
-        id: 'autocomplete',
         container,
         onStateChange,
       });
@@ -261,7 +263,6 @@ describe('api', () => {
       );
       const container = document.createElement('div');
       const { destroy } = autocomplete<{ label: string }>({
-        id: 'autocomplete',
         container,
       });
 

--- a/packages/autocomplete-js/src/__tests__/api.test.ts
+++ b/packages/autocomplete-js/src/__tests__/api.test.ts
@@ -179,7 +179,7 @@ describe('api', () => {
   });
 
   describe('setContext', () => {
-    test('aggregate `context` values in the state', () => {
+    test('aggregates `context` values in the state', () => {
       const onStateChange = jest.fn();
       const container = document.createElement('div');
       const { setContext } = autocomplete<{ label: string }>({
@@ -210,7 +210,7 @@ describe('api', () => {
   });
 
   describe('update', () => {
-    test('merge new options with original ones', () => {
+    test('merges new options with original ones', () => {
       let inputElement: HTMLInputElement;
       const onStateChange = jest.fn();
       const container = document.createElement('div');
@@ -253,7 +253,7 @@ describe('api', () => {
   });
 
   describe('destroy', () => {
-    test('clear all effects', () => {
+    test('clears all effects', () => {
       const windowAddEventListenerSpy = jest.spyOn(window, 'addEventListener');
       const windowRemoveEventListenerSpy = jest.spyOn(
         window,

--- a/packages/autocomplete-js/src/__tests__/api.test.ts
+++ b/packages/autocomplete-js/src/__tests__/api.test.ts
@@ -1,19 +1,276 @@
+import { fireEvent, waitFor } from '@testing-library/dom';
+
+import { autocomplete } from '../autocomplete';
+import {
+  createAutocomplete,
+  AutocompleteCollection,
+} from '@algolia/autocomplete-core';
+
+function createCollection(items) {
+  return {
+    source: {
+      getItemInputValue: ({ item }) => item.label,
+      getItemUrl: () => undefined,
+      onActive: () => {},
+      onSelect: () => {},
+      getItems: () => items,
+      templates: {},
+    },
+    items,
+  };
+}
+
 describe('api', () => {
   describe('setActiveItemId', () => {
-    test.todo('tests');
+    test('sets `activeItemId` value in the state', () => {
+      const onStateChange = jest.fn();
+      const container = document.createElement('div');
+      const { setActiveItemId } = autocomplete<{ label: string }>({
+        id: 'autocomplete',
+        container,
+        onStateChange,
+      });
+
+      setActiveItemId(1);
+
+      expect(onStateChange).toHaveBeenCalledTimes(1);
+      expect(onStateChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({ activeItemId: 1 }),
+        })
+      );
+
+      setActiveItemId(null);
+
+      expect(onStateChange).toHaveBeenCalledTimes(2);
+      expect(onStateChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({ activeItemId: null }),
+        })
+      );
+    });
   });
 
-  describe('setQuery', () => {});
+  describe('setQuery', () => {
+    test('sets `query` value in the state', () => {
+      const onStateChange = jest.fn();
+      const container = document.createElement('div');
+      const { setQuery } = autocomplete<{ label: string }>({
+        id: 'autocomplete',
+        container,
+        onStateChange,
+      });
 
-  describe('setCollections', () => {});
+      setQuery('query');
 
-  describe('setIsOpen', () => {});
+      expect(onStateChange).toHaveBeenCalledTimes(1);
+      expect(onStateChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({ query: 'query' }),
+        })
+      );
+    });
+  });
 
-  describe('setStatus', () => {});
+  describe('setCollections', () => {
+    test('sets the collections', () => {
+      const onStateChange = jest.fn();
+      const container = document.createElement('div');
+      const { setCollections } = autocomplete<{ label: string }>({
+        id: 'autocomplete',
+        container,
+        onStateChange,
+      });
 
-  describe('setContext', () => {});
+      setCollections([createCollection([{ label: 'hi' }])]);
 
-  describe('update', () => {});
+      expect(onStateChange).toHaveBeenCalledTimes(1);
+      expect(onStateChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({
+            collections: [
+              {
+                items: [
+                  {
+                    label: 'hi',
+                    __autocomplete_id: 0,
+                  },
+                ],
+                source: expect.any(Object),
+              },
+            ],
+          }),
+        })
+      );
+    });
 
-  describe('destroy', () => {});
+    test('flattens the collections', () => {
+      const onStateChange = jest.fn();
+      const { setCollections } = createAutocomplete({
+        openOnFocus: true,
+        onStateChange,
+      });
+
+      setCollections([createCollection([[{ label: 'hi' }]])]);
+
+      expect(onStateChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({
+            collections: [
+              expect.objectContaining({
+                items: [{ label: 'hi', __autocomplete_id: 0 }],
+              }),
+            ],
+          }),
+        })
+      );
+    });
+  });
+
+  describe('setIsOpen', () => {
+    test('sets `isOpen` value in the state', () => {
+      const onStateChange = jest.fn();
+      const container = document.createElement('div');
+      const { setIsOpen } = autocomplete<{ label: string }>({
+        id: 'autocomplete',
+        container,
+        onStateChange,
+      });
+
+      setIsOpen(true);
+
+      expect(onStateChange).toHaveBeenCalledTimes(1);
+      expect(onStateChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({ isOpen: true }),
+        })
+      );
+
+      setIsOpen(false);
+
+      expect(onStateChange).toHaveBeenCalledTimes(2);
+      expect(onStateChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({ isOpen: false }),
+        })
+      );
+    });
+  });
+
+  describe('setStatus', () => {
+    test('sets `status` value in the state', () => {
+      const onStateChange = jest.fn();
+      const container = document.createElement('div');
+      const { setStatus } = autocomplete<{ label: string }>({
+        id: 'autocomplete',
+        container,
+        onStateChange,
+      });
+
+      setStatus('loading');
+
+      expect(onStateChange).toHaveBeenCalledTimes(1);
+      expect(onStateChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({ status: 'loading' }),
+        })
+      );
+    });
+  });
+
+  describe('setContext', () => {
+    test('aggregate `context` values in the state', () => {
+      const onStateChange = jest.fn();
+      const container = document.createElement('div');
+      const { setContext } = autocomplete<{ label: string }>({
+        id: 'autocomplete',
+        container,
+        onStateChange,
+      });
+
+      setContext({
+        firstContext: 'firstContextValue',
+      });
+      setContext({
+        secondContext: 'secondContextValue',
+      });
+
+      expect(onStateChange).toHaveBeenCalledTimes(2);
+      expect(onStateChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({
+            context: {
+              firstContext: 'firstContextValue',
+              secondContext: 'secondContextValue',
+            },
+          }),
+        })
+      );
+    });
+  });
+
+  describe('update', () => {
+    test('merge new options with original ones', () => {
+      let inputElement: HTMLInputElement;
+      const onStateChange = jest.fn();
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const { update } = autocomplete<{ label: string }>({
+        id: 'autocomplete',
+        container,
+        onStateChange,
+      });
+
+      // Focusing the input should do nothing (`openOnFocus` is false)
+      inputElement = container.querySelector('.aa-Input');
+      inputElement.focus();
+
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({
+            isOpen: false,
+          }),
+        })
+      );
+
+      // Update options (set `openOnFocus` to true)
+      update({
+        openOnFocus: true,
+      });
+
+      // Focusing the input should open the panel (`openOnFocus` is now true)
+      inputElement = container.querySelector('.aa-Input');
+      inputElement.focus();
+
+      expect(onStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({
+            isOpen: true,
+          }),
+        })
+      );
+    });
+  });
+
+  describe('destroy', () => {
+    test('clear all effects', () => {
+      const windowAddEventListenerSpy = jest.spyOn(window, 'addEventListener');
+      const windowRemoveEventListenerSpy = jest.spyOn(
+        window,
+        'removeEventListener'
+      );
+      const container = document.createElement('div');
+      const { destroy } = autocomplete<{ label: string }>({
+        id: 'autocomplete',
+        container,
+      });
+
+      destroy();
+
+      // Use one side effect (event listeners on window) to check that all events where cleared
+      expect(windowRemoveEventListenerSpy.mock.calls.length).toEqual(
+        windowAddEventListenerSpy.mock.calls.length
+      );
+    });
+  });
 });

--- a/packages/autocomplete-js/src/__tests__/classNames.test.ts
+++ b/packages/autocomplete-js/src/__tests__/classNames.test.ts
@@ -1,5 +1,50 @@
-describe('classNames', () => {
-  test.todo('merges with default CSS classes');
+import { waitFor } from '@testing-library/dom';
 
-  test.todo('dedupes CSS classes');
+import { autocomplete } from '../autocomplete';
+
+describe('classNames', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('merges with default CSS classes', async () => {
+    autocomplete({
+      container,
+      classNames: {
+        form: 'aa-test-Form',
+        input: 'aa-test-Input',
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('.aa-Form.aa-test-Form')
+      ).toBeInTheDocument();
+      expect(
+        document.querySelector('.aa-Input.aa-test-Input')
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('dedupes CSS classes', async () => {
+    autocomplete({
+      container,
+      classNames: {
+        form: 'aa-Form',
+        input: 'aa-Input',
+      },
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('.aa-Form')).toBeInTheDocument();
+      expect(document.querySelector('.aa-Input')).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/autocomplete-js/src/__tests__/classNames.test.ts
+++ b/packages/autocomplete-js/src/__tests__/classNames.test.ts
@@ -43,8 +43,13 @@ describe('classNames', () => {
     });
 
     await waitFor(() => {
-      expect(document.querySelector('.aa-Form')).toBeInTheDocument();
-      expect(document.querySelector('.aa-Input')).toBeInTheDocument();
+      const form = document.querySelector('.aa-Form');
+      const input = document.querySelector('.aa-Input');
+
+      expect(form).toBeInTheDocument();
+      expect(form.className).toEqual('aa-Form');
+      expect(input).toBeInTheDocument();
+      expect(input.className).toEqual('aa-Input');
     });
   });
 });

--- a/packages/autocomplete-js/src/__tests__/panelContainer.test.ts
+++ b/packages/autocomplete-js/src/__tests__/panelContainer.test.ts
@@ -1,3 +1,65 @@
+import { waitFor } from '@testing-library/dom';
+
+import { autocomplete } from '../autocomplete';
+
 describe('panelContainer', () => {
-  test.todo('tests');
+  let container;
+  let panelContainer;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    panelContainer = document.createElement('div');
+    panelContainer.className = 'customPanelContainer';
+    document.body.appendChild(container);
+    document.body.appendChild(panelContainer);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('default value is `document.body`', async () => {
+    autocomplete({
+      container,
+      initialState: {
+        isOpen: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(document.body.lastChild).toHaveClass('aa-Panel');
+    });
+  });
+
+  test('create panel in the specified element', async () => {
+    autocomplete({
+      container,
+      panelContainer,
+      initialState: {
+        isOpen: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(panelContainer).toContainElement(
+        document.querySelector('.aa-Panel')
+      );
+    });
+  });
+
+  test('create panel in the element targeted by the selector', async () => {
+    autocomplete({
+      container,
+      panelContainer: '.customPanelContainer',
+      initialState: {
+        isOpen: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(panelContainer).toContainElement(
+        document.querySelector('.aa-Panel')
+      );
+    });
+  });
 });

--- a/packages/autocomplete-js/src/__tests__/panelContainer.test.ts
+++ b/packages/autocomplete-js/src/__tests__/panelContainer.test.ts
@@ -3,22 +3,14 @@ import { waitFor } from '@testing-library/dom';
 import { autocomplete } from '../autocomplete';
 
 describe('panelContainer', () => {
-  let container;
-  let panelContainer;
-
-  beforeEach(() => {
-    container = document.createElement('div');
-    panelContainer = document.createElement('div');
-    panelContainer.className = 'customPanelContainer';
-    document.body.appendChild(container);
-    document.body.appendChild(panelContainer);
-  });
-
   afterEach(() => {
     document.body.innerHTML = '';
   });
 
   test('default value is `document.body`', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
     autocomplete({
       container,
       initialState: {
@@ -32,6 +24,11 @@ describe('panelContainer', () => {
   });
 
   test('create panel in the specified element', async () => {
+    const container = document.createElement('div');
+    const panelContainer = document.createElement('div');
+    document.body.appendChild(container);
+    document.body.appendChild(panelContainer);
+
     autocomplete({
       container,
       panelContainer,
@@ -48,6 +45,12 @@ describe('panelContainer', () => {
   });
 
   test('create panel in the element targeted by the selector', async () => {
+    const container = document.createElement('div');
+    const panelContainer = document.createElement('div');
+    panelContainer.className = 'customPanelContainer';
+    document.body.appendChild(container);
+    document.body.appendChild(panelContainer);
+
     autocomplete({
       container,
       panelContainer: '.customPanelContainer',

--- a/packages/autocomplete-js/src/__tests__/panelPlacement.test.ts
+++ b/packages/autocomplete-js/src/__tests__/panelPlacement.test.ts
@@ -1,3 +1,233 @@
+import { waitFor } from '@testing-library/dom';
+
+import { autocomplete } from '../autocomplete';
+
+// Arbitrary values to mock `getBoundingClientRect`, `offsetTop` and `clientWidth`
+// (by default jest mock everything to 0 but we cannot properly check the calculations if everything is set to 0)
+const OFFSET_TOP = 2;
+const CLIENT_WIDTH = 3;
+const BOTTOM = 5;
+const HEIGHT = 7;
+const LEFT = 11;
+const RIGHT = 13;
+const TOP = 17;
+const WIDTH = 19;
+
 describe('panelPlacement', () => {
-  test.todo('tests');
+  let container: HTMLDivElement;
+  const mockedGetBoundingClientRect = (): DOMRect => ({
+    bottom: BOTTOM,
+    height: HEIGHT,
+    left: LEFT,
+    right: RIGHT,
+    top: TOP,
+    width: WIDTH,
+    x: 0,
+    y: 0,
+    toJSON: () => {},
+  });
+
+  beforeAll(() => {
+    Object.defineProperty(window.HTMLElement.prototype, 'offsetTop', {
+      get() {
+        return OFFSET_TOP;
+      },
+    });
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      get() {
+        return CLIENT_WIDTH;
+      },
+    });
+  });
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window.HTMLElement.prototype, 'offsetTop', {
+      get() {
+        return 0;
+      },
+    });
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      get() {
+        return 0;
+      },
+    });
+  });
+
+  describe('with `input-wrapper-width` value', () => {
+    test('places the panel bellow the input and takes the input width', async () => {
+      autocomplete({
+        container,
+        panelPlacement: 'input-wrapper-width',
+        initialState: {
+          isOpen: true,
+        },
+      });
+
+      // Mock `getBoundingClientRect` for elements used in the panel placement calculation
+      document.querySelector(
+        '.aa-Form'
+      ).getBoundingClientRect = mockedGetBoundingClientRect;
+      document.querySelector(
+        '.aa-Autocomplete'
+      ).getBoundingClientRect = mockedGetBoundingClientRect;
+
+      await waitFor(() => {
+        expect(document.querySelector('.aa-Panel')).toHaveStyle({
+          top: '9px', // OFFSET_TOP + HEIGHT
+          left: '11px', // LEFT
+          right: '-27px', // CLIENT_WIDTH - (LEFT + WIDTH)
+          width: 'unset',
+          'max-width': 'unset',
+        });
+      });
+    });
+  });
+
+  describe('with `start` value', () => {
+    test('places the panel bellow the input and align it with the input left side', async () => {
+      autocomplete({
+        container,
+        panelPlacement: 'start',
+        initialState: {
+          isOpen: true,
+        },
+      });
+
+      // Mock `getBoundingClientRect` for elements used in the panel placement calculation
+      document.querySelector(
+        '.aa-Form'
+      ).getBoundingClientRect = mockedGetBoundingClientRect;
+      document.querySelector(
+        '.aa-Autocomplete'
+      ).getBoundingClientRect = mockedGetBoundingClientRect;
+
+      await waitFor(() => {
+        expect(document.querySelector('.aa-Panel')).toHaveStyle({
+          top: '9px', // OFFSET_TOP + HEIGHT
+          left: '11px', // LEFT
+        });
+      });
+    });
+  });
+
+  describe('with `end` value', () => {
+    test('places the panel bellow the input and align it with the input right side', async () => {
+      autocomplete({
+        container,
+        panelPlacement: 'end',
+        initialState: {
+          isOpen: true,
+        },
+      });
+
+      // Mock `getBoundingClientRect` for elements used in the panel placement calculation
+      document.querySelector(
+        '.aa-Form'
+      ).getBoundingClientRect = mockedGetBoundingClientRect;
+      document.querySelector(
+        '.aa-Autocomplete'
+      ).getBoundingClientRect = mockedGetBoundingClientRect;
+
+      await waitFor(() => {
+        expect(document.querySelector('.aa-Panel')).toHaveStyle({
+          top: '9px', // OFFSET_TOP + HEIGHT
+          right: '-27px', // CLIENT_WIDTH - (LEFT + WIDTH)
+        });
+      });
+    });
+  });
+
+  describe('with `full-width` value', () => {
+    test('places the panel bellow the input and takes the full page width', async () => {
+      autocomplete({
+        container,
+        panelPlacement: 'full-width',
+        initialState: {
+          isOpen: true,
+        },
+      });
+
+      // Mock `getBoundingClientRect` for elements used in the panel placement calculation
+      document.querySelector(
+        '.aa-Form'
+      ).getBoundingClientRect = mockedGetBoundingClientRect;
+      document.querySelector(
+        '.aa-Autocomplete'
+      ).getBoundingClientRect = mockedGetBoundingClientRect;
+
+      await waitFor(() => {
+        expect(document.querySelector('.aa-Panel')).toHaveStyle({
+          top: '9px', // OFFSET_TOP + HEIGHT
+          left: 0,
+          right: 0,
+          width: 'unset',
+          'max-width': 'unset',
+        });
+      });
+    });
+  });
+
+  test('behaves like `input-wrapper-width` if no value is set', async () => {
+    autocomplete({
+      container,
+      initialState: {
+        isOpen: true,
+      },
+    });
+
+    // Mock `getBoundingClientRect` for elements used in the panel placement calculation
+    document.querySelector(
+      '.aa-Form'
+    ).getBoundingClientRect = mockedGetBoundingClientRect;
+    document.querySelector(
+      '.aa-Autocomplete'
+    ).getBoundingClientRect = mockedGetBoundingClientRect;
+
+    await waitFor(() => {
+      expect(document.querySelector('.aa-Panel')).toHaveStyle({
+        top: '9px', // OFFSET_TOP + HEIGHT
+        left: '11px', // LEFT
+        right: '-27px', // CLIENT_WIDTH - (LEFT + WIDTH)
+        width: 'unset',
+        'max-width': 'unset',
+      });
+    });
+  });
+
+  // eslint-disable-next-line jest/no-done-callback
+  test('throws an error if an invalid value is used', async (done) => {
+    window.addEventListener(
+      'error',
+      (error) => {
+        error.preventDefault();
+        expect(error.message).toEqual(
+          'The `panelPlacement` value "invalid" is not valid.'
+        );
+        done();
+      },
+      { once: true }
+    );
+
+    autocomplete({
+      container,
+      // @ts-expect-error
+      panelPlacement: 'invalid',
+      initialState: {
+        isOpen: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('.aa-Panel')).toHaveStyle({});
+    });
+  });
 });

--- a/packages/autocomplete-js/src/__tests__/panelPlacement.test.ts
+++ b/packages/autocomplete-js/src/__tests__/panelPlacement.test.ts
@@ -63,7 +63,7 @@ describe('panelPlacement', () => {
   });
 
   describe('with `input-wrapper-width` value', () => {
-    test('places the panel bellow the input and takes the input width', async () => {
+    test('places the panel below the input and takes the input width', async () => {
       autocomplete({
         container,
         panelPlacement: 'input-wrapper-width',
@@ -93,7 +93,7 @@ describe('panelPlacement', () => {
   });
 
   describe('with `start` value', () => {
-    test('places the panel bellow the input and align it with the input left side', async () => {
+    test('places the panel below the input and aligns it with the input left side', async () => {
       autocomplete({
         container,
         panelPlacement: 'start',
@@ -120,7 +120,7 @@ describe('panelPlacement', () => {
   });
 
   describe('with `end` value', () => {
-    test('places the panel bellow the input and align it with the input right side', async () => {
+    test('places the panel below the input and aligns it with the input right side', async () => {
       autocomplete({
         container,
         panelPlacement: 'end',
@@ -147,7 +147,7 @@ describe('panelPlacement', () => {
   });
 
   describe('with `full-width` value', () => {
-    test('places the panel bellow the input and takes the full page width', async () => {
+    test('places the panel below the input and takes the full page width', async () => {
       autocomplete({
         container,
         panelPlacement: 'full-width',


### PR DESCRIPTION
Add multiple tests for:

* autocomplete API:
  * `setActiveItemId`
  * `setQuery`
  * `setCollections`
  * `setIsOpen`
  * `setStatus`
  * `setContext`
  * `update`
  * `destroy`
* `classnames` option
* `panelContainer` option
* `panelPlacement` option