### PR TITLE
docs(guides): update Multiple Result Types guide

### DIFF
--- a/packages/website/docs/creating-multi-source-autocompletes.md
+++ b/packages/website/docs/creating-multi-source-autocompletes.md
@@ -210,7 +210,9 @@ In this example, [`getItems`](sources/#getitems) returns a filtered array of `pr
 
 The [`getItemUrl`](sources/#getitemurl) function defines how to get the URL of an item. In this case, since it's an attribute on each object in the `predefinedItems` array, you can simply return the attribute. You can use [`getItemUrl`](sources/#getitemurl) to add [keyboard navigation](keyboard-navigation) to the autocomplete menu. Users can scroll through items in the autocomplete menu with the arrow up and down keys. When they hit <kbd>Enter</kbd> on one of the `predefinedItems` (or any source that includes[`getItemUrl`](sources/#getitemurl)), it opens the URL retrieved from [`getItemUrl`](sources/#getitemurl).
 
-[Templates](templates) define how to display each section of the autocomplete, including the [`header`](templates#header), [`footer`](templates#footer), and each [`item`](templates#item). You can return anything from each template as long as they're valid virtual DOM elements (VNodes).
+[Templates](templates) define how to display each section of the autocomplete, including the [`header`](templates#header), [`footer`](templates#footer), and each [`item`](templates#item). Templates can return anything that is a valid virtual DOM element (VNode).
+
+This example defines how to display each predefined item with the [`item`](templates#item) template and gives a [`header`](templates#header) for the entire section.
 
 ```js title="predefinedItemsPlugin.js"
 const predefinedItems = [
@@ -389,7 +391,7 @@ This shows up to five recent searches (set by the [`limit`](createLocalStorageRe
 
 ### Separating result types
 
-We recommend separating different result types with headers when using sources other than just Recent Searches and Query Suggestions. We can use the `transformSource` option of the plugins.
+When using sources other than just recent and suggested searches, it's best to label the different result types with [`headers`](templates/#header). For the `createLocalStorageRecentSearchesPlugin` and `createQuerySuggestionsPlugin` plugins, you can use the [`transformSource`](createquerysuggestionsplugin/#transformsource) option to do this.
 
 ```js title="index.js"
 import { autocomplete } from '@algolia/autocomplete-js';

--- a/packages/website/src/components/AutocompleteExample.tsx
+++ b/packages/website/src/components/AutocompleteExample.tsx
@@ -32,7 +32,11 @@ export function AutocompleteExample<TItem extends BaseItem>(
   return (
     <div
       ref={containerRef}
-      style={{ marginBottom: 'var(--ifm-paragraph-margin-bottom)' }}
+      style={{
+        margin: 'auto',
+        marginBottom: 'var(--ifm-paragraph-margin-bottom)',
+        maxWidth: 540,
+      }}
     />
   );
 }


### PR DESCRIPTION
## Description

This updates the Multiple Result Types guide with a better example component design and documents how to add `header` templates to QS and RS plugins.

## Preview

![image](https://user-images.githubusercontent.com/6137112/108201450-20e98880-7120-11eb-9672-411ed8bedcd9.png)
