### PR TITLE
docs(guides): add section to use QS and RS as links

### DIFF
--- a/packages/website/docs/adding-recent-searches.md
+++ b/packages/website/docs/adding-recent-searches.md
@@ -98,7 +98,7 @@ const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
 });
 ```
 
-If you use Autocomplete on your instant search page, you can plug some logic with `onSelect`:
+If you use Autocomplete on the same page as your main search and want to avoid reloading the full page when an item is selected, you can modify your search query state when a user selects an item with [`onSelect`](sources/#onselect):
 
 ```js
 const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({

--- a/packages/website/docs/adding-recent-searches.md
+++ b/packages/website/docs/adding-recent-searches.md
@@ -68,9 +68,11 @@ Since the `recentSearchesPlugin` reads from [`localStorage`](https://developer.m
   openOnFocus={true}
 />
 
-## Transforming recent searches
+## Customizing recent searches
 
-If you use Autocomplete as an entry point to a search page, you can turn recent searches into links:
+The [`createLocalStorageRecentSearchesPlugin`](createLocalStorageRecentSearchesPlugin) creates a functional plugin out of the box. You may want to customize some aspects of it, depending on your use case. To change [`templates`](templates) or other [source](sources) configuration options, you can use [`transformSource`](createLocalStorageRecentSearchesPlugin/#transformsource). The function includes the original `source`, which you should return along with any options you want to add or overwrite.
+
+For example, if you use Autocomplete as an entry point to a search results page, you can turn recent searches into links by modifying [`getItemUrl`](sources/#getitemurl) and the [`item`](templates#item) template.
 
 ```js
 const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({

--- a/packages/website/docs/adding-recent-searches.md
+++ b/packages/website/docs/adding-recent-searches.md
@@ -49,7 +49,7 @@ The `key` can be any string and is required to differentiate search histories if
 import { autocomplete } from '@algolia/autocomplete-js';
 import { createLocalStorageRecentSearchesPlugin } from '@algolia/autocomplete-plugin-recent-searches';
 
- const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
+const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
   key: 'RECENT_SEARCH',
   limit: 5,
 });
@@ -67,6 +67,51 @@ Since the `recentSearchesPlugin` reads from [`localStorage`](https://developer.m
   plugins={[recentSearchesPlugin]}
   openOnFocus={true}
 />
+
+## Transforming recent searches
+
+If you use Autocomplete as an entry point to a search page, you can turn recent searches into links:
+
+```js
+const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
+  // ...
+  transformSource({ source }) {
+    return {
+      ...source,
+      getItemUrl({ item }) {
+        return `/search?q=${item.query}`;
+      },
+      templates: {
+        item(params) {
+          const { item } = params;
+          return (
+            <a className="aa-ItemLink" href={`/search?q=${item.query}`}>
+              {source.templates.item(params)}
+            </a>
+          );
+        },
+      },
+    };
+  },
+});
+```
+
+If you use Autocomplete on your instant search page, you can plug some logic with `onSelect`:
+
+```js
+const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
+  // ...
+  transformSource({ source }) {
+    return {
+      ...source,
+      onSelect({ item }) {
+        // Assuming the refine function updates the search page state.
+        refine(item.query);
+      }
+    };
+  },
+});
+```
 
 ## Using your own storage
 

--- a/packages/website/docs/adding-suggested-searches.md
+++ b/packages/website/docs/adding-suggested-searches.md
@@ -126,9 +126,11 @@ These suggestions are based on a [public dataset of BestBuy products](https://gi
 
 :::
 
-## Transforming Query Suggestions
+## Customizing Query Suggestions
 
-If you use Autocomplete as an entry point to a search page, you can turn Query Suggestions into links:
+The [`createQuerySuggestionsPlugin`](createQuerySuggestionsPlugin) creates a functional plugin out of the box. You may want to customize some aspects of it, depending on your use case. To change [`templates`](templates) or other [source](sources) configuration options, you can use [`transformSource`](createQuerySuggestionsPlugin/#transformsource). The function includes the original `source`, which you should return along with any options you want to add or overwrite.
+
+For example, if you use Autocomplete as an entry point to a search results page, you can turn Query Suggestions into links by modifying [`getItemUrl`](sources/#getitemurl) and the [`item`](templates#item) template.
 
 ```js
 const querySuggestionsPlugin = createQuerySuggestionsPlugin({
@@ -174,4 +176,3 @@ const querySuggestionsPlugin = createQuerySuggestionsPlugin({
 ## Next steps
 
 This tutorial focuses on adding Query Suggestions to an autocomplete menu. Many autocomplete menus also include recent searches and possibly other items. Check out the guides on adding [recent searches](adding-recent-searches) and [static predefined items](sources#using-static-sources) for more information. To learn how to display multiple sections in one autocomplete, read the [guide on adding mulitple categories in one autocomplete](including-multiple-result-types).
-

--- a/packages/website/docs/adding-suggested-searches.md
+++ b/packages/website/docs/adding-suggested-searches.md
@@ -126,6 +126,51 @@ These suggestions are based on a [public dataset of BestBuy products](https://gi
 
 :::
 
+## Transforming Query Suggestions
+
+If you use Autocomplete as an entry point to a search page, you can turn Query Suggestions into links:
+
+```js
+const querySuggestionsPlugin = createQuerySuggestionsPlugin({
+  // ...
+  transformSource({ source }) {
+    return {
+      ...source,
+      getItemUrl({ item }) {
+        return `/search?q=${item.query}`;
+      },
+      templates: {
+        item(params) {
+          const { item } = params;
+          return (
+            <a className="aa-ItemLink" href={`/search?q=${item.query}`}>
+              {source.templates.item(params)}
+            </a>
+          );
+        },
+      },
+    };
+  },
+});
+```
+
+If you use Autocomplete on your instant search page, you can plug some logic with `onSelect`:
+
+```js
+const querySuggestionsPlugin = createQuerySuggestionsPlugin({
+  // ...
+  transformSource({ source }) {
+    return {
+      ...source,
+      onSelect({ item }) {
+        // Assuming the refine function updates the search page state.
+        refine(item.query);
+      }
+    };
+  },
+});
+```
+
 ## Next steps
 
 This tutorial focuses on adding Query Suggestions to an autocomplete menu. Many autocomplete menus also include recent searches and possibly other items. Check out the guides on adding [recent searches](adding-recent-searches) and [static predefined items](sources#using-static-sources) for more information. To learn how to display multiple sections in one autocomplete, read the [guide on adding mulitple categories in one autocomplete](including-multiple-result-types).

--- a/packages/website/docs/adding-suggested-searches.md
+++ b/packages/website/docs/adding-suggested-searches.md
@@ -156,7 +156,7 @@ const querySuggestionsPlugin = createQuerySuggestionsPlugin({
 });
 ```
 
-If you use Autocomplete on your instant search page, you can plug some logic with `onSelect`:
+If you use Autocomplete on the same page as your main search and want to avoid reloading the full page when an item is selected, you can modify your search query state when a user selects an item with [`onSelect`](sources/#onselect):
 
 ```js
 const querySuggestionsPlugin = createQuerySuggestionsPlugin({


### PR DESCRIPTION
This adds a section in both the Query Suggestions and the Recent Searches guide to explain how to turn items into links. This is a common use case when using Autocomplete as an entry point to your search page.