### PR TITLE
feat(js): rename `empty` to `noResults`

### DIFF
--- a/examples/js/app.tsx
+++ b/examples/js/app.tsx
@@ -102,7 +102,7 @@ autocomplete({
               />
             );
           },
-          empty() {
+          noResults() {
             return (
               <div className="aa-ItemContent">No products for this query.</div>
             );

--- a/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
+++ b/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
@@ -149,7 +149,7 @@ describe('autocomplete-js', () => {
     `);
   });
 
-  test('renders empty template on no results', async () => {
+  test('renders noResults template on no results', async () => {
     const container = document.createElement('div');
     const panelContainer = document.createElement('div');
 
@@ -169,7 +169,7 @@ describe('autocomplete-js', () => {
               item({ item }) {
                 return item.label;
               },
-              empty() {
+              noResults() {
                 return 'No results template';
               },
             },
@@ -189,7 +189,7 @@ describe('autocomplete-js', () => {
     });
   });
 
-  test("doesn't render empty template on no query when openOnFocus is false", async () => {
+  test("doesn't render noResults template on no query when openOnFocus is false", async () => {
     const container = document.createElement('div');
     const panelContainer = document.createElement('div');
 
@@ -209,7 +209,7 @@ describe('autocomplete-js', () => {
               item({ item }) {
                 return item.label;
               },
-              empty() {
+              noResults() {
                 return 'No results template';
               },
             },
@@ -229,7 +229,7 @@ describe('autocomplete-js', () => {
     });
   });
 
-  test('render empty template on query when openOnFocus is false', async () => {
+  test('render noResults template on query when openOnFocus is false', async () => {
     const container = document.createElement('div');
     const panelContainer = document.createElement('div');
 
@@ -249,7 +249,7 @@ describe('autocomplete-js', () => {
               item({ item }) {
                 return item.label;
               },
-              empty() {
+              noResults() {
                 return 'No results template';
               },
             },
@@ -269,10 +269,10 @@ describe('autocomplete-js', () => {
     });
   });
 
-  test('calls renderEmpty without empty template on no results', async () => {
+  test('calls renderNoResults without noResults template on no results', async () => {
     const container = document.createElement('div');
     const panelContainer = document.createElement('div');
-    const renderEmpty = jest.fn((_params, root) => {
+    const renderNoResults = jest.fn((_params, root) => {
       const div = document.createElement('div');
       div.innerHTML = 'No results render';
 
@@ -299,7 +299,7 @@ describe('autocomplete-js', () => {
           },
         ];
       },
-      renderEmpty,
+      renderNoResults,
     });
 
     const input = container.querySelector<HTMLInputElement>('.aa-Input');
@@ -312,7 +312,7 @@ describe('autocomplete-js', () => {
       ).toHaveTextContent('No results render');
     });
 
-    expect(renderEmpty).toHaveBeenCalledWith(
+    expect(renderNoResults).toHaveBeenCalledWith(
       {
         state: expect.anything(),
         children: expect.anything(),
@@ -324,7 +324,7 @@ describe('autocomplete-js', () => {
     );
   });
 
-  test('renders empty template over renderEmpty method on no results', async () => {
+  test('renders noResults template over renderNoResults method on no results', async () => {
     const container = document.createElement('div');
     const panelContainer = document.createElement('div');
 
@@ -344,14 +344,14 @@ describe('autocomplete-js', () => {
               item({ item }) {
                 return item.label;
               },
-              empty() {
+              noResults() {
                 return 'No results template';
               },
             },
           },
         ];
       },
-      renderEmpty(_params, root) {
+      renderNoResults(_params, root) {
         const div = document.createElement('div');
         div.innerHTML = 'No results render';
 

--- a/packages/autocomplete-js/src/__tests__/renderEmpty.test.ts
+++ b/packages/autocomplete-js/src/__tests__/renderEmpty.test.ts
@@ -1,3 +1,0 @@
-describe('renderEmpty', () => {
-  test.todo('tests');
-});

--- a/packages/autocomplete-js/src/__tests__/renderNoResults.test.ts
+++ b/packages/autocomplete-js/src/__tests__/renderNoResults.test.ts
@@ -1,0 +1,3 @@
+describe('renderNoResults', () => {
+  test.todo('tests');
+});

--- a/packages/autocomplete-js/src/autocomplete.ts
+++ b/packages/autocomplete-js/src/autocomplete.ts
@@ -30,7 +30,7 @@ export function autocomplete<TItem extends BaseItem>(
   const { runEffect, cleanupEffects, runEffects } = createEffectWrapper();
   const { reactive, runReactives } = createReactiveWrapper();
 
-  const hasEmptySourceTemplateRef = createRef(false);
+  const hasNoResultsSourceTemplateRef = createRef(false);
   const optionsRef = createRef(options);
   const onStateChangeRef = createRef<
     AutocompleteOptions<TItem>['onStateChange']
@@ -46,9 +46,9 @@ export function autocomplete<TItem extends BaseItem>(
     createAutocomplete<TItem>({
       ...props.value.core,
       onStateChange(options) {
-        hasEmptySourceTemplateRef.current = options.state.collections.some(
+        hasNoResultsSourceTemplateRef.current = options.state.collections.some(
           (collection) =>
-            (collection.source as AutocompleteSource<TItem>).templates.empty
+            (collection.source as AutocompleteSource<TItem>).templates.noResults
         );
         onStateChangeRef.current?.(options as any);
         props.value.core.onStateChange?.(options as any);
@@ -62,12 +62,12 @@ export function autocomplete<TItem extends BaseItem>(
             return hasItems;
           }
 
-          const hasEmptyTemplate = Boolean(
-            hasEmptySourceTemplateRef.current ||
-              props.value.renderer.renderEmpty
+          const hasNoResultsTemplate = Boolean(
+            hasNoResultsSourceTemplateRef.current ||
+              props.value.renderer.renderNoResults
           );
 
-          return (!hasItems && hasEmptyTemplate) || hasItems;
+          return (!hasItems && hasNoResultsTemplate) || hasItems;
         }),
     })
   );
@@ -147,8 +147,8 @@ export function autocomplete<TItem extends BaseItem>(
 
     const render =
       (!getItemsCount(state) &&
-        !hasEmptySourceTemplateRef.current &&
-        props.value.renderer.renderEmpty) ||
+        !hasNoResultsSourceTemplateRef.current &&
+        props.value.renderer.renderNoResults) ||
       props.value.renderer.render;
 
     renderSearchBox(renderProps);

--- a/packages/autocomplete-js/src/getDefaultOptions.ts
+++ b/packages/autocomplete-js/src/getDefaultOptions.ts
@@ -38,7 +38,7 @@ const defaultClassNames: AutocompleteClassNames = {
   source: 'aa-Source',
   sourceFooter: 'aa-SourceFooter',
   sourceHeader: 'aa-SourceHeader',
-  sourceEmpty: 'aa-SourceEmpty',
+  sourceNoResults: 'aa-SourceNoResults',
   submitButton: 'aa-SubmitButton',
 };
 
@@ -68,7 +68,7 @@ export function getDefaultOptions<TItem extends BaseItem>(
     panelContainer,
     panelPlacement,
     render,
-    renderEmpty,
+    renderNoResults,
     renderer,
     detachedMediaQuery,
     ...core
@@ -105,7 +105,7 @@ export function getDefaultOptions<TItem extends BaseItem>(
         : document.body,
       panelPlacement: panelPlacement ?? 'input-wrapper-width',
       render: render ?? defaultRender,
-      renderEmpty,
+      renderNoResults,
       renderer: renderer ?? defaultRenderer,
       detachedMediaQuery:
         detachedMediaQuery ??

--- a/packages/autocomplete-js/src/render.tsx
+++ b/packages/autocomplete-js/src/render.tsx
@@ -105,9 +105,9 @@ export function renderPanel<TItem extends BaseItem>(
         </div>
       )}
 
-      {items.length === 0 && source.templates.empty && state.query ? (
-        <div className={classNames.sourceEmpty}>
-          {source.templates.empty({
+      {items.length === 0 && source.templates.noResults && state.query ? (
+        <div className={classNames.sourceNoResults}>
+          {source.templates.noResults({
             createElement,
             Fragment,
             source,

--- a/packages/autocomplete-js/src/types/AutocompleteClassNames.ts
+++ b/packages/autocomplete-js/src/types/AutocompleteClassNames.ts
@@ -20,8 +20,8 @@ export type AutocompleteClassNames = {
   resetButton: string;
   root: string;
   source: string;
-  sourceEmpty: string;
   sourceFooter: string;
   sourceHeader: string;
+  sourceNoResults: string;
   submitButton: string;
 };

--- a/packages/autocomplete-js/src/types/AutocompleteOptions.ts
+++ b/packages/autocomplete-js/src/types/AutocompleteOptions.ts
@@ -65,7 +65,7 @@ export interface AutocompleteOptions<TItem extends BaseItem>
    * The default implementation appends all the sections to the root.
    */
   render?: AutocompleteRender<TItem>;
-  renderEmpty?: AutocompleteRender<TItem>;
+  renderNoResults?: AutocompleteRender<TItem>;
   initialState?: Partial<AutocompleteState<TItem>>;
   onStateChange?(props: OnStateChangeProps<TItem>): void;
   /**

--- a/packages/autocomplete-js/src/types/AutocompleteSource.ts
+++ b/packages/autocomplete-js/src/types/AutocompleteSource.ts
@@ -41,9 +41,9 @@ export type SourceTemplates<TItem extends BaseItem> = {
     items: TItem[];
   }>;
   /**
-   * The template for the empty section.
+   * The template for the no results section.
    */
-  empty?: Template<{
+  noResults?: Template<{
     state: AutocompleteState<TItem>;
     source: AutocompleteSource<TItem>;
   }>;

--- a/packages/autocomplete-theme-classic/src/theme.scss
+++ b/packages/autocomplete-theme-classic/src/theme.scss
@@ -273,8 +273,7 @@ body {
       display: none;
     }
   }
-  // todo: rename to SourceNoResults
-  .aa-SourceEmpty {
+  .aa-SourceNoResults {
     padding: var(--aa-spacing);
   }
   &:empty {

--- a/packages/website/docs/autocomplete-js.md
+++ b/packages/website/docs/autocomplete-js.md
@@ -142,24 +142,24 @@ autocomplete({
 });
 ```
 
-### `renderEmpty`
+### `renderNoResults`
 
-> `(params: { root: HTMLElement, state: AutocompleteState<TItem>, sections: VNode[], createElement: Pragma, Fragment: PragmaFrag }) => void`
+> `(params: { children: VNode, state: AutocompleteState<TItem>, sections: VNode[], createElement: Pragma, Fragment: PragmaFrag }) => void`
 
-Function called to render an empty section when no hits are returned. It is useful for letting the user know that the query returned no results.
+Function called to render a no results section when no hits are returned. It is useful for letting the user know that the query returned no results.
 
 There is no default implementation, which closes the panel when there's no results.
 
-````js
+```js
+import { render } from 'preact';
+
 autocomplete({
   // ...
-  renderEmpty(_params, root) {
-    const div = document.createElement('div');
-
-    div.innerHTML = 'Your query returned no results';
-    root.appendChild(div);
+  renderNoResults({ state }, root) {
+    render(`No results for "${state.query}".`, root);
   },
 });
+```
 
 ### `renderer`
 
@@ -187,7 +187,7 @@ const {
   setContext,
   refresh,
 } = autocomplete(options);
-````
+```
 
 `autocomplete` returns all the [state setters](state#setters) and `refresh` method that updates the UI state.
 

--- a/packages/website/docs/autocomplete-theme-classic.md
+++ b/packages/website/docs/autocomplete-theme-classic.md
@@ -134,13 +134,13 @@ autocomplete({
 });
 ```
 
-### Empty
+### No Results
 
 ```jsx
 autocomplete({
   // ...
   templates: {
-    empty() {
+    noResults() {
       return <div className="aa-ItemContent">No results for this query.</div>;
     },
     // ...

--- a/packages/website/docs/plugins.md
+++ b/packages/website/docs/plugins.md
@@ -37,6 +37,7 @@ autocomplete({
   plugins: [algoliaInsightsPlugin],
 });
 ```
+
 :::note
 
 Plugins execute sequentially, in the order you define them.
@@ -74,7 +75,7 @@ const gitHubReposPlugin = {
 
             return `${item.name} (${stars} stars)`;
           },
-          empty() {
+          noResults() {
             return 'No results.';
           },
         },
@@ -125,7 +126,7 @@ export function createGitHubReposPlugin(options) {
 
                   return `${item.full_name} (${stars} stars)`;
                 },
-                empty() {
+                noResults() {
                   return 'No results.';
                 },
               },

--- a/packages/website/docs/templates.md
+++ b/packages/website/docs/templates.md
@@ -184,9 +184,9 @@ autocomplete({
 });
 ```
 
-### Rendering an empty state
+### Rendering a no results state
 
-When there are no results, you might want to display a message to inform users or let them know what to do next. You can do this with the [`empty`](#empty) template.
+When there are no results, you might want to display a message to inform users or let them know what to do next. You can do this with the [`noResults`](#noresults) template.
 
 ```js
 autocomplete({
@@ -197,7 +197,7 @@ autocomplete({
         // ...
         templates: {
           // ...
-          empty() {
+          noResults() {
             return 'No results.';
           },
         },
@@ -299,7 +299,7 @@ A function that returns the template for each item of the source.
 
 A function that returns the template for the footer (after the list of items).
 
-### `empty`
+### `noResults`
 
 > `(params: { state: AutocompleteState<TItem>, source: AutocompleteSource<TItem>, createElement: Pragma, Fragment: PragmaFrag }) => VNode | string`
 

--- a/packages/website/docs/upgrading.md
+++ b/packages/website/docs/upgrading.md
@@ -24,18 +24,18 @@ Read more about [installation options](getting-started#installation) in the [**G
 These parameters and how you use them have changed from [Autocomplete v0](https://github.com/algolia/autocomplete.js/blob/45fa32d008620cf52bf4a90530be338543dfba7f/README.md#global-options):
 
 | v0 | v1 |
-| ----------- | ----------- |
+| --- | --- |
 | [`autocomplete('#autocomplete', /* ... */)`](https://github.com/algolia/autocomplete.js/blob/45fa32d008620cf52bf4a90530be338543dfba7f/README.md#global-options) | [`autocomplete({ container: '#autocomplete', /* ... */ })`](autocomplete-js/#container) |
 | [`autoselect: true`](https://github.com/algolia/autocomplete.js/blob/45fa32d008620cf52bf4a90530be338543dfba7f/README.md#global-options) | `defaultActiveItemId: 0` |
 | [`autoselectOnBlur: true`](https://github.com/algolia/autocomplete.js/blob/45fa32d008620cf52bf4a90530be338543dfba7f/README.md#global-options) | No longer needed; this is the default behavior |
 | [`tabAutocomplete: true`](https://github.com/algolia/autocomplete.js/blob/45fa32d008620cf52bf4a90530be338543dfba7f/README.md#global-options) | No longer supported; v1 implements the ARIA 1.1 form of the [combobox design pattern](https://www.w3.org/TR/wai-aria-practices/#combobox) |
 | [`hint`](https://github.com/algolia/autocomplete.js/blob/45fa32d008620cf52bf4a90530be338543dfba7f/README.md#global-options) | No longer supported |
-| [`clearOnSelected`](https://github.com/algolia/autocomplete.js/blob/45fa32d008620cf52bf4a90530be338543dfba7f/README.md#global-options) | This is now local to the [source](sources): [`getItemInputValue: () => ''`](sources/#getiteminputvalue)|
+| [`clearOnSelected`](https://github.com/algolia/autocomplete.js/blob/45fa32d008620cf52bf4a90530be338543dfba7f/README.md#global-options) | This is now local to the [source](sources): [`getItemInputValue: () => ''`](sources/#getiteminputvalue) |
 | [`dropdownMenuContainer`](https://github.com/algolia/autocomplete.js/blob/45fa32d008620cf52bf4a90530be338543dfba7f/README.md#global-options) | [`panelContainer`](autocomplete-js/#panelcontainer) |
-| [`templates`](https://github.com/algolia/autocomplete.js/blob/45fa32d008620cf52bf4a90530be338543dfba7f/README.md#global-options) (top-level) | [`render`](autocomplete-js/#render) and [`renderEmpty`](autocomplete-js/#renderempty) |
+| [`templates`](https://github.com/algolia/autocomplete.js/blob/45fa32d008620cf52bf4a90530be338543dfba7f/README.md#global-options) (top-level) | [`render`](autocomplete-js/#render) and [`renderNoResults`](autocomplete-js/#rendernoresults) |
 | [`cssClasses`](https://github.com/algolia/autocomplete.js/blob/45fa32d008620cf52bf4a90530be338543dfba7f/README.md#global-options) | [`classNames`](autocomplete-js/#classnames) where properties have changed |
 | [`keyboardShortcuts`](https://github.com/algolia/autocomplete.js/blob/45fa32d008620cf52bf4a90530be338543dfba7f/README.md#global-options) | No longer supported as an option; check out the [keyboard navigation docs](keyboard-navigation) |
-| [`minLength: 0`](https://github.com/algolia/autocomplete.js/blob/45fa32d008620cf52bf4a90530be338543dfba7f/README.md#global-options) | [`openOnFocus: true`](autocomplete-js/#openonfocus)  |
+| [`minLength: 0`](https://github.com/algolia/autocomplete.js/blob/45fa32d008620cf52bf4a90530be338543dfba7f/README.md#global-options) | [`openOnFocus: true`](autocomplete-js/#openonfocus) |
 
 ## Datasets
 
@@ -47,7 +47,10 @@ These parameters and how you use them have changed from [Autocomplete v0](https:
 
 ## Templates
 
-The `suggestion` template is renamed [`item`](templates#item). Learn more about [**Templates** concept](templates).
+- The `suggestion` template is renamed [`item`](templates#item).
+- The `empty` template is renamed [`noResults`](templates#noresults).
+
+Learn more about [**Templates** concept](templates).
 
 ## Top-level API
 


### PR DESCRIPTION
## Why

The name `empty` was rather confusing and `noResults` reflects better when this template is displayed.

## What

This renames all params that contain `empty` to `noResults`:

- `templates.empty` → `templates.noResults`
- `renderEmpty` → `renderNoResults`
- `.aa-SourceEmpty` → `.aa-SourceNoResults`