### PR TITLE
feat(algolia): add `getAlgoliaFacetHits` preset

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "packages/autocomplete-js/dist/umd/index.production.js",
-      "maxSize": "14.25 kB"
+      "maxSize": "14.50 kB"
     },
     {
       "path": "packages/autocomplete-preset-algolia/dist/umd/index.production.js",

--- a/examples/js/app.tsx
+++ b/examples/js/app.tsx
@@ -17,6 +17,7 @@ import insightsClient from 'search-insights';
 
 import '@algolia/autocomplete-theme-classic';
 
+import { createCategoriesPlugin } from './categoriesPlugin';
 import { shortcutsPlugin } from './shortcutsPlugin';
 
 type Product = {
@@ -49,6 +50,7 @@ const querySuggestionsPlugin = createQuerySuggestionsPlugin({
   },
   categoryAttribute: 'categories',
 });
+const categoriesPlugin = createCategoriesPlugin({ searchClient });
 
 autocomplete({
   container: '#autocomplete',
@@ -60,6 +62,7 @@ autocomplete({
     algoliaInsightsPlugin,
     recentSearchesPlugin,
     querySuggestionsPlugin,
+    categoriesPlugin,
   ],
   getSources({ query, state }) {
     if (!query) {

--- a/examples/js/categoriesPlugin.tsx
+++ b/examples/js/categoriesPlugin.tsx
@@ -1,0 +1,87 @@
+/** @jsx h */
+import {
+  AutocompletePlugin,
+  getAlgoliaFacetHits,
+  highlightHit,
+} from '@algolia/autocomplete-js';
+import { Hit } from '@algolia/client-search';
+import { SearchClient } from 'algoliasearch/lite';
+import { h, Fragment } from 'preact';
+
+type CategoryItem = {
+  label: string;
+  count: number;
+};
+
+type CreateCategoriesPluginProps = {
+  searchClient: SearchClient;
+};
+
+export function createCategoriesPlugin({
+  searchClient,
+}: CreateCategoriesPluginProps): AutocompletePlugin<CategoryItem, undefined> {
+  return {
+    getSources({ query }) {
+      return [
+        {
+          sourceId: 'categoriesPlugin',
+          getItems() {
+            return getAlgoliaFacetHits({
+              searchClient,
+              queries: [
+                {
+                  indexName: 'instant_search',
+                  params: {
+                    facetName: 'categories',
+                    facetQuery: query,
+                    maxFacetHits: query ? 3 : 10,
+                  },
+                },
+              ],
+            });
+          },
+          templates: {
+            header() {
+              return (
+                <Fragment>
+                  <span className="aa-SourceHeaderTitle">Categories</span>
+                  <div className="aa-SourceHeaderLine" />
+                </Fragment>
+              );
+            },
+            item({ item }) {
+              return (
+                <Fragment>
+                  <div className="aa-ItemIcon aa-ItemIcon--no-border">
+                    <svg
+                      viewBox="0 0 24 24"
+                      width="18"
+                      height="18"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+                      <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
+                      <line x1="12" y1="22.08" x2="12" y2="12" />
+                    </svg>
+                  </div>
+                  <div className="aa-ItemContent">
+                    <div className="aa-ItemContentTitle">
+                      {highlightHit<Hit<CategoryItem>>({
+                        hit: item as any,
+                        attribute: 'label',
+                      })}
+                    </div>
+                  </div>
+                </Fragment>
+              );
+            },
+          },
+        },
+      ];
+    },
+  };
+}

--- a/packages/autocomplete-js/src/__tests__/getAlgoliaFacetHits.test.ts
+++ b/packages/autocomplete-js/src/__tests__/getAlgoliaFacetHits.test.ts
@@ -1,0 +1,29 @@
+import algoliaPreset from '@algolia/autocomplete-preset-algolia';
+
+import { createSearchClient } from '../../../../test/utils';
+import { getAlgoliaFacetHits } from '../getAlgoliaFacetHits';
+import { version } from '../version';
+
+jest.mock('@algolia/autocomplete-preset-algolia', () => {
+  const module = jest.requireActual('@algolia/autocomplete-preset-algolia');
+
+  return {
+    ...module,
+    getAlgoliaFacetHits: jest.fn(),
+  };
+});
+
+describe('getAlgoliaFacetHits', () => {
+  test('forwards params to the preset function', () => {
+    const searchClient = createSearchClient();
+
+    getAlgoliaFacetHits({ searchClient, queries: [] });
+
+    expect(algoliaPreset.getAlgoliaFacetHits).toHaveBeenCalledTimes(1);
+    expect(algoliaPreset.getAlgoliaFacetHits).toHaveBeenCalledWith({
+      searchClient,
+      queries: [],
+      userAgents: [{ segment: 'autocomplete-js', version }],
+    });
+  });
+});

--- a/packages/autocomplete-js/src/getAlgoliaFacetHits.ts
+++ b/packages/autocomplete-js/src/getAlgoliaFacetHits.ts
@@ -1,0 +1,17 @@
+import {
+  getAlgoliaFacetHits as getAlgoliaFacetHitsOriginal,
+  SearchForFacetValuesParams,
+} from '@algolia/autocomplete-preset-algolia';
+
+import { version } from './version';
+
+export function getAlgoliaFacetHits({
+  searchClient,
+  queries,
+}: Pick<SearchForFacetValuesParams, 'searchClient' | 'queries'>) {
+  return getAlgoliaFacetHitsOriginal({
+    searchClient,
+    queries,
+    userAgents: [{ segment: 'autocomplete-js', version }],
+  });
+}

--- a/packages/autocomplete-js/src/index.ts
+++ b/packages/autocomplete-js/src/index.ts
@@ -1,4 +1,5 @@
 export * from './autocomplete';
+export * from './getAlgoliaFacetHits';
 export * from './getAlgoliaHits';
 export * from './getAlgoliaResults';
 export * from './highlight';

--- a/packages/autocomplete-preset-algolia/src/index.ts
+++ b/packages/autocomplete-preset-algolia/src/index.ts
@@ -2,6 +2,8 @@ export * from './highlight/parseAlgoliaHitHighlight';
 export * from './highlight/parseAlgoliaHitReverseHighlight';
 export * from './highlight/parseAlgoliaHitReverseSnippet';
 export * from './highlight/parseAlgoliaHitSnippet';
+export * from './search/getAlgoliaFacetHits';
 export * from './search/getAlgoliaHits';
 export * from './search/getAlgoliaResults';
+export type { SearchForFacetValuesParams } from './search/searchForFacetValues';
 export type { SearchParams } from './search/search';

--- a/packages/autocomplete-preset-algolia/src/search/UserAgent.ts
+++ b/packages/autocomplete-preset-algolia/src/search/UserAgent.ts
@@ -1,0 +1,1 @@
+export type UserAgent = { segment: string; version?: string };

--- a/packages/autocomplete-preset-algolia/src/search/__tests__/search.test.ts
+++ b/packages/autocomplete-preset-algolia/src/search/__tests__/search.test.ts
@@ -1,8 +1,10 @@
 import {
+  createSFFVResponse,
   createMultiSearchResponse,
   createSearchClient,
 } from '../../../../../test/utils';
 import { version } from '../../version';
+import { getAlgoliaFacetHits } from '../getAlgoliaFacetHits';
 import { getAlgoliaHits } from '../getAlgoliaHits';
 import { getAlgoliaResults } from '../getAlgoliaResults';
 
@@ -15,6 +17,24 @@ function createTestSearchClient() {
           { hits: [{ objectID: '2', label: 'Hit 2' }] }
         )
       )
+    ),
+    searchForFacetValues: jest.fn(() =>
+      Promise.resolve([
+        createSFFVResponse({
+          facetHits: [
+            {
+              count: 507,
+              value: 'Mobile phones',
+              highlighted: 'Mobile <em>phone</em>s',
+            },
+            {
+              count: 63,
+              value: 'Phone cases',
+              highlighted: '<em>Phone</em> cases',
+            },
+          ],
+        }),
+      ])
     ),
   });
 }
@@ -238,6 +258,161 @@ describe('getAlgoliaHits', () => {
     const searchClient = createTestSearchClient();
 
     await getAlgoliaHits({
+      searchClient,
+      queries: [],
+      userAgents: [{ segment: 'custom-ua', version: '1.0.0' }],
+    });
+
+    expect(searchClient.addAlgoliaAgent).toHaveBeenCalledTimes(2);
+    expect(searchClient.addAlgoliaAgent).toHaveBeenNthCalledWith(
+      1,
+      'autocomplete-core',
+      version
+    );
+    expect(searchClient.addAlgoliaAgent).toHaveBeenNthCalledWith(
+      2,
+      'custom-ua',
+      '1.0.0'
+    );
+  });
+});
+
+describe('getAlgoliaFacetHits', () => {
+  test('with default options', async () => {
+    const searchClient = createTestSearchClient();
+
+    const facetHits = await getAlgoliaFacetHits({
+      searchClient,
+      queries: [
+        {
+          indexName: 'indexName',
+          params: {
+            facetName: 'facetName',
+            facetQuery: 'facetQuery',
+          },
+        },
+      ],
+    });
+
+    expect(searchClient.searchForFacetValues).toHaveBeenCalledTimes(1);
+    expect(searchClient.searchForFacetValues).toHaveBeenCalledWith([
+      {
+        indexName: 'indexName',
+        params: {
+          facetName: 'facetName',
+          facetQuery: 'facetQuery',
+          highlightPreTag: '__aa-highlight__',
+          highlightPostTag: '__/aa-highlight__',
+        },
+      },
+    ]);
+    expect(facetHits).toEqual([
+      [
+        {
+          count: 507,
+          label: 'Mobile phones',
+          _highlightResult: {
+            label: {
+              value: 'Mobile <em>phone</em>s',
+            },
+          },
+        },
+        {
+          count: 63,
+          label: 'Phone cases',
+          _highlightResult: {
+            label: {
+              value: '<em>Phone</em> cases',
+            },
+          },
+        },
+      ],
+    ]);
+  });
+
+  test('with custom search parameters', async () => {
+    const searchClient = createTestSearchClient();
+
+    const facetHits = await getAlgoliaFacetHits({
+      searchClient,
+      queries: [
+        {
+          indexName: 'indexName',
+          params: {
+            facetName: 'facetName',
+            facetQuery: 'facetQuery',
+            highlightPreTag: '<em>',
+            highlightPostTag: '</em>',
+            maxFacetHits: 10,
+          },
+        },
+      ],
+    });
+
+    expect(searchClient.searchForFacetValues).toHaveBeenCalledTimes(1);
+    expect(searchClient.searchForFacetValues).toHaveBeenCalledWith([
+      {
+        indexName: 'indexName',
+        params: {
+          facetName: 'facetName',
+          facetQuery: 'facetQuery',
+          highlightPreTag: '<em>',
+          highlightPostTag: '</em>',
+          maxFacetHits: 10,
+        },
+      },
+    ]);
+    expect(facetHits).toEqual([
+      [
+        {
+          count: 507,
+          label: 'Mobile phones',
+          _highlightResult: {
+            label: {
+              value: 'Mobile <em>phone</em>s',
+            },
+          },
+        },
+        {
+          count: 63,
+          label: 'Phone cases',
+          _highlightResult: {
+            label: {
+              value: '<em>Phone</em> cases',
+            },
+          },
+        },
+      ],
+    ]);
+  });
+
+  test('attaches Algolia agent', async () => {
+    const searchClient = createTestSearchClient();
+
+    await getAlgoliaFacetHits({
+      searchClient,
+      queries: [
+        {
+          indexName: 'indexName',
+          params: {
+            facetName: 'facetName',
+            facetQuery: 'facetQuery',
+          },
+        },
+      ],
+    });
+
+    expect(searchClient.addAlgoliaAgent).toHaveBeenCalledTimes(1);
+    expect(searchClient.addAlgoliaAgent).toHaveBeenCalledWith(
+      'autocomplete-core',
+      version
+    );
+  });
+
+  test('allows custom user agents', async () => {
+    const searchClient = createTestSearchClient();
+
+    await getAlgoliaFacetHits({
       searchClient,
       queries: [],
       userAgents: [{ segment: 'custom-ua', version: '1.0.0' }],

--- a/packages/autocomplete-preset-algolia/src/search/getAlgoliaFacetHits.ts
+++ b/packages/autocomplete-preset-algolia/src/search/getAlgoliaFacetHits.ts
@@ -1,0 +1,38 @@
+import {
+  searchForFacetValues,
+  SearchForFacetValuesParams,
+} from './searchForFacetValues';
+
+type FacetHit = {
+  label: string;
+  count: number;
+  _highlightResult: {
+    label: {
+      value: string;
+    };
+  };
+};
+
+export function getAlgoliaFacetHits({
+  searchClient,
+  queries,
+  userAgents,
+}: SearchForFacetValuesParams): Promise<FacetHit[][]> {
+  return searchForFacetValues({ searchClient, queries, userAgents }).then(
+    (response) => {
+      return response.map((result) =>
+        result.facetHits.map((facetHit) => {
+          return {
+            label: facetHit.value,
+            count: facetHit.count,
+            _highlightResult: {
+              label: {
+                value: facetHit.highlighted,
+              },
+            },
+          };
+        })
+      );
+    }
+  );
+}

--- a/packages/autocomplete-preset-algolia/src/search/searchForFacetValues.ts
+++ b/packages/autocomplete-preset-algolia/src/search/searchForFacetValues.ts
@@ -1,4 +1,7 @@
-import { MultipleQueriesQuery } from '@algolia/client-search';
+import {
+  SearchForFacetValuesQueryParams,
+  SearchOptions,
+} from '@algolia/client-search';
 import { SearchClient } from 'algoliasearch/lite';
 
 import { HIGHLIGHT_PRE_TAG, HIGHLIGHT_POST_TAG } from '../constants';
@@ -6,17 +9,21 @@ import { version } from '../version';
 
 import { UserAgent } from './UserAgent';
 
-export interface SearchParams {
+type FacetQuery = {
+  indexName: string;
+  params: SearchForFacetValuesQueryParams & SearchOptions;
+};
+export interface SearchForFacetValuesParams {
   searchClient: SearchClient;
-  queries: MultipleQueriesQuery[];
+  queries: FacetQuery[];
   userAgents?: UserAgent[];
 }
 
-export function search<TRecord>({
+export function searchForFacetValues({
   searchClient,
   queries,
   userAgents = [],
-}: SearchParams) {
+}: SearchForFacetValuesParams) {
   if (typeof searchClient.addAlgoliaAgent === 'function') {
     const algoliaAgents: UserAgent[] = [
       { segment: 'autocomplete-core', version },
@@ -28,15 +35,13 @@ export function search<TRecord>({
     });
   }
 
-  return searchClient.search<TRecord>(
+  return searchClient.searchForFacetValues(
     queries.map((searchParameters) => {
-      const { indexName, query, params } = searchParameters;
+      const { indexName, params } = searchParameters;
 
       return {
         indexName,
-        query,
         params: {
-          hitsPerPage: 5,
           highlightPreTag: HIGHLIGHT_PRE_TAG,
           highlightPostTag: HIGHLIGHT_POST_TAG,
           ...params,

--- a/packages/website/docs/getAlgoliaFacetHits-js.md
+++ b/packages/website/docs/getAlgoliaFacetHits-js.md
@@ -1,0 +1,35 @@
+---
+id: getAlgoliaFacetHits-js
+title: getAlgoliaFacetHits
+---
+
+Retrieves Algolia facet hits from multiple indices.
+
+## Example
+
+```js
+import { getAlgoliaFacetHits } from '@algolia/autocomplete-js';
+import algoliasearch from 'algoliasearch/lite';
+
+const searchClient = algoliasearch(APP_ID, SEARCH_API_KEY);
+
+getAlgoliaFacetHits({
+  searchClient,
+  queries: [
+    {
+      indexName: 'instant_search',
+      params: {
+        facetName: 'categories',
+        facetQuery: query,
+        maxFacetHits: 10,
+      },
+    },
+  ],
+}).then((facetHits) => {
+  console.log(facetHits);
+});
+```
+
+## Params
+
+See [`autocomplete-preset-algolia#getAlgoliaFacetHits`](getAlgoliaFacetHits#params).

--- a/packages/website/docs/getAlgoliaFacetHits.md
+++ b/packages/website/docs/getAlgoliaFacetHits.md
@@ -1,0 +1,82 @@
+---
+id: getAlgoliaFacetHits
+---
+
+Retrieves Algolia facet hits from multiple indices.
+
+## Example
+
+```js
+import { getAlgoliaFacetHits } from '@algolia/autocomplete-preset-algolia';
+import algoliasearch from 'algoliasearch/lite';
+
+const searchClient = algoliasearch(APP_ID, SEARCH_API_KEY);
+
+getAlgoliaFacetHits({
+  searchClient,
+  queries: [
+    {
+      indexName: 'instant_search',
+      params: {
+        facetName: 'categories',
+        facetQuery: query,
+        maxFacetHits: 10,
+      },
+    },
+  ],
+}).then((facetHits) => {
+  console.log(facetHits);
+});
+```
+
+## Params
+
+### `searchClient`
+
+> `SearchClient` | required
+
+### `queries`
+
+#### `indexName`
+
+> `string` | required
+
+#### `params`
+
+> [`SearchParameters`](https://www.algolia.com/doc/api-reference/search-api-parameters/) & [`Request Options`](https://www.algolia.com/doc/api-client/getting-started/request-options/) | required
+
+Default search parameters:
+
+```json
+{
+  "highlightPreTag": "__aa-highlight__",
+  "highlightPostTag": "__/aa-highlight__"
+}
+```
+
+## Returns
+
+It returns a promise of the following schema:
+
+```json
+[
+  {
+    "count": 507,
+    "label": "Mobile phones",
+    "_highlightResult": {
+      "label": {
+        "value": "Mobile <em>phone</em>s"
+      }
+    }
+  },
+  {
+    "count": 63,
+    "label": "Phone cases",
+    "_highlightResult": {
+      "label": {
+        "value": "<em>Phone</em> cases"
+      }
+    }
+  }
+]
+```

--- a/packages/website/docs/getAlgoliaHits-js.md
+++ b/packages/website/docs/getAlgoliaHits-js.md
@@ -3,7 +3,7 @@ id: getAlgoliaHits-js
 title: getAlgoliaHits
 ---
 
-Retrieves and merges Algolia hits from one or multiple indices.
+Retrieves Algolia hits from multiple indices into arrays of records.
 
 ## Example
 

--- a/packages/website/docs/getAlgoliaResults-js.md
+++ b/packages/website/docs/getAlgoliaResults-js.md
@@ -3,7 +3,7 @@ id: getAlgoliaResults-js
 title: getAlgoliaResults
 ---
 
-Retrieves Algolia results from one or multiple indices.
+Retrieves Algolia results from multiple indices.
 
 ## Example
 

--- a/packages/website/docs/getAlgoliaResults.md
+++ b/packages/website/docs/getAlgoliaResults.md
@@ -2,7 +2,7 @@
 id: getAlgoliaResults
 ---
 
-Retrieves the full Algolia results from multiple indices
+Retrieves Algolia results from multiple indices.
 
 ## Example
 

--- a/packages/website/sidebars.js
+++ b/packages/website/sidebars.js
@@ -38,6 +38,7 @@ module.exports = {
           'autocomplete-js',
           'getAlgoliaHits-js',
           'getAlgoliaResults-js',
+          'getAlgoliaFacetHits-js',
           'highlightHit',
           'reverseHighlightHit',
           'snippetHit',
@@ -68,6 +69,7 @@ module.exports = {
         items: [
           'getAlgoliaHits',
           'getAlgoliaResults',
+          'getAlgoliaFacetHits',
           'parseAlgoliaHitHighlight',
           'parseAlgoliaHitReverseHighlight',
           'parseAlgoliaHitSnippet',


### PR DESCRIPTION
## Description

The `getAlgoliaFacetHits` function is an additional search util to our `@algolia/autocomplete-preset-algolia` package.

We now have:

- `getAlgoliaHits`
- `getAlgoliaResults`
- `getAlgoliaFacetHits`

This function is useful to search for facets in the Autocomplete panel. Later, it will be useful when using Autocomplete Tags to refine the query to a category as a first step of the flow.

## Preview

![image](https://user-images.githubusercontent.com/6137112/108389852-5cfc1680-7210-11eb-8b0e-3beefa54c161.png)

## Implementation

The `getAlgoliaFacetHits` function returns a similar format to React InstantSearch's facet hits from `connectRefinementList`. This allows to use highlighting utils (e.g., `highlightHit`) with facet hits.


```json
[
  {
    "count": 507,
    "label": "Mobile phones",
    "_highlightResult": {
      "label": {
        "value": "Mobile <em>phone</em>s"
      }
    }
  },
  {
    "count": 63,
    "label": "Phone cases",
    "_highlightResult": {
      "label": {
        "value": "<em>Phone</em> cases"
      }
    }
  }
]
```