### PR TITLE
fix(core): compute open state on focus with `shouldPanelOpen`

### DIFF
--- a/packages/autocomplete-core/src/__tests__/debug.test.ts
+++ b/packages/autocomplete-core/src/__tests__/debug.test.ts
@@ -14,6 +14,7 @@ describe('debug', () => {
     const { getInputProps } = createAutocomplete({
       debug: true,
       openOnFocus: true,
+      shouldPanelOpen: () => true,
       onStateChange,
     });
     const inputElement = document.createElement('input');

--- a/packages/autocomplete-core/src/__tests__/getEnvironmentProps.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getEnvironmentProps.test.ts
@@ -209,6 +209,7 @@ describe('getEnvironmentProps', () => {
         formElement,
       } = createPlayground(createAutocomplete, {
         openOnFocus: true,
+        shouldPanelOpen: () => true,
       });
       const panelElement = document.createElement('div');
 

--- a/packages/autocomplete-core/src/__tests__/getFormProps.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getFormProps.test.ts
@@ -251,6 +251,7 @@ describe('getFormProps', () => {
         {
           onStateChange,
           openOnFocus: true,
+          shouldPanelOpen: () => true,
           initialState: {
             isOpen: true,
           },

--- a/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
@@ -1514,80 +1514,164 @@ describe('getInputProps', () => {
     });
 
     describe('set isOpen', () => {
-      test('to false when openOnFocus is false and the query empty', () => {
-        const onStateChange = jest.fn();
-        const { inputElement } = createPlayground(createAutocomplete, {
-          onStateChange,
+      describe('shouldPanelOpen returns false', () => {
+        test('to false when openOnFocus is false and the query empty', () => {
+          const onStateChange = jest.fn();
+          const { inputElement } = createPlayground(createAutocomplete, {
+            onStateChange,
+          });
+
+          inputElement.focus();
+
+          expect(onStateChange).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              state: expect.objectContaining({
+                isOpen: false,
+              }),
+            })
+          );
         });
 
-        inputElement.focus();
+        test('to true when the query is set', () => {
+          const onStateChange = jest.fn();
+          const { inputElement } = createPlayground(createAutocomplete, {
+            onStateChange,
+            initialState: {
+              query: 'i',
+            },
+          });
 
-        expect(onStateChange).toHaveBeenLastCalledWith(
-          expect.objectContaining({
-            state: expect.objectContaining({
-              isOpen: false,
-            }),
-          })
-        );
+          inputElement.focus();
+
+          expect(onStateChange).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              state: expect.objectContaining({
+                isOpen: false,
+              }),
+            })
+          );
+        });
+
+        test('to true when openOnFocus is true', () => {
+          const onStateChange = jest.fn();
+          const { inputElement } = createPlayground(createAutocomplete, {
+            onStateChange,
+            openOnFocus: true,
+          });
+
+          inputElement.focus();
+
+          expect(onStateChange).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              state: expect.objectContaining({
+                isOpen: false,
+              }),
+            })
+          );
+        });
+
+        test('to true when openOnFocus is true and the query is set', () => {
+          const onStateChange = jest.fn();
+          const { inputElement } = createPlayground(createAutocomplete, {
+            onStateChange,
+            openOnFocus: true,
+            initialState: {
+              query: 'i',
+            },
+          });
+
+          inputElement.focus();
+
+          expect(onStateChange).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              state: expect.objectContaining({
+                isOpen: false,
+              }),
+            })
+          );
+        });
       });
 
-      test('to true when the query is set', () => {
-        const onStateChange = jest.fn();
-        const { inputElement } = createPlayground(createAutocomplete, {
-          onStateChange,
-          initialState: {
-            query: 'i',
-          },
+      describe('shouldPanelOpen returns true', () => {
+        test('to false when openOnFocus is false and the query empty', () => {
+          const onStateChange = jest.fn();
+          const { inputElement } = createPlayground(createAutocomplete, {
+            onStateChange,
+            shouldPanelOpen: () => true,
+          });
+
+          inputElement.focus();
+
+          expect(onStateChange).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              state: expect.objectContaining({
+                isOpen: false,
+              }),
+            })
+          );
         });
 
-        inputElement.focus();
+        test('to true when the query is set', () => {
+          const onStateChange = jest.fn();
+          const { inputElement } = createPlayground(createAutocomplete, {
+            onStateChange,
+            shouldPanelOpen: () => true,
+            initialState: {
+              query: 'i',
+            },
+          });
 
-        expect(onStateChange).toHaveBeenLastCalledWith(
-          expect.objectContaining({
-            state: expect.objectContaining({
-              isOpen: true,
-            }),
-          })
-        );
-      });
+          inputElement.focus();
 
-      test('to true when openOnFocus is true', () => {
-        const onStateChange = jest.fn();
-        const { inputElement } = createPlayground(createAutocomplete, {
-          onStateChange,
-          openOnFocus: true,
+          expect(onStateChange).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              state: expect.objectContaining({
+                isOpen: true,
+              }),
+            })
+          );
         });
 
-        inputElement.focus();
+        test('to true when openOnFocus is true', () => {
+          const onStateChange = jest.fn();
+          const { inputElement } = createPlayground(createAutocomplete, {
+            onStateChange,
+            openOnFocus: true,
+            shouldPanelOpen: () => true,
+          });
 
-        expect(onStateChange).toHaveBeenLastCalledWith(
-          expect.objectContaining({
-            state: expect.objectContaining({
-              isOpen: true,
-            }),
-          })
-        );
-      });
+          inputElement.focus();
 
-      test('to true when openOnFocus is true and the query is set', () => {
-        const onStateChange = jest.fn();
-        const { inputElement } = createPlayground(createAutocomplete, {
-          onStateChange,
-          openOnFocus: true,
-          initialState: {
-            query: 'i',
-          },
+          expect(onStateChange).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              state: expect.objectContaining({
+                isOpen: true,
+              }),
+            })
+          );
         });
 
-        inputElement.focus();
+        test('to true when openOnFocus is true and the query is set', () => {
+          const onStateChange = jest.fn();
+          const { inputElement } = createPlayground(createAutocomplete, {
+            onStateChange,
+            openOnFocus: true,
+            shouldPanelOpen: () => true,
+            initialState: {
+              query: 'i',
+            },
+          });
 
-        expect(onStateChange).toHaveBeenLastCalledWith(
-          expect.objectContaining({
-            state: expect.objectContaining({
-              isOpen: true,
-            }),
-          })
-        );
+          inputElement.focus();
+
+          expect(onStateChange).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              state: expect.objectContaining({
+                isOpen: true,
+              }),
+            })
+          );
+        });
       });
     });
   });
@@ -1621,6 +1705,7 @@ describe('getInputProps', () => {
         debug: true,
         defaultActiveItemId: 1,
         openOnFocus: true,
+        shouldPanelOpen: () => true,
       });
 
       inputElement.focus();
@@ -1647,6 +1732,7 @@ describe('getInputProps', () => {
         onStateChange,
         defaultActiveItemId: 1,
         openOnFocus: true,
+        shouldPanelOpen: () => true,
       });
 
       inputElement.focus();
@@ -1680,6 +1766,7 @@ describe('getInputProps', () => {
       const { inputElement } = createPlayground(createAutocomplete, {
         onStateChange,
         openOnFocus: true,
+        shouldPanelOpen: () => true,
         initialState: {
           isOpen: true,
         },
@@ -1770,6 +1857,7 @@ describe('getInputProps', () => {
           const onStateChange = jest.fn();
           const { inputElement } = createPlayground(createAutocomplete, {
             onStateChange,
+            shouldPanelOpen: () => true,
             initialState: {
               query: 'i',
             },
@@ -1796,6 +1884,7 @@ describe('getInputProps', () => {
           const { inputElement } = createPlayground(createAutocomplete, {
             onStateChange,
             openOnFocus: true,
+            shouldPanelOpen: () => true,
           });
 
           inputElement.focus();
@@ -1820,6 +1909,7 @@ describe('getInputProps', () => {
         const { inputElement } = createPlayground(createAutocomplete, {
           onStateChange,
           openOnFocus: true,
+          shouldPanelOpen: () => true,
         });
 
         inputElement.focus();

--- a/packages/autocomplete-core/src/__tests__/openOnFocus.test.ts
+++ b/packages/autocomplete-core/src/__tests__/openOnFocus.test.ts
@@ -34,7 +34,10 @@ describe('openOnFocus', () => {
 
   test('opens panel on reset', () => {
     const onStateChange = jest.fn();
-    const { formElement } = setupTest({ onStateChange });
+    const { formElement } = setupTest({
+      onStateChange,
+      shouldPanelOpen: () => true,
+    });
 
     formElement.reset();
 
@@ -94,7 +97,10 @@ describe('openOnFocus', () => {
 
   test('opens panel without query', () => {
     const onStateChange = jest.fn();
-    const { inputElement } = setupTest({ onStateChange });
+    const { inputElement } = setupTest({
+      onStateChange,
+      shouldPanelOpen: () => true,
+    });
 
     inputElement.focus();
 

--- a/packages/autocomplete-core/src/stateReducer.ts
+++ b/packages/autocomplete-core/src/stateReducer.ts
@@ -133,7 +133,9 @@ export const stateReducer: Reducer = (state, action) => {
       return {
         ...state,
         activeItemId: action.props.defaultActiveItemId,
-        isOpen: action.props.openOnFocus || Boolean(state.query),
+        isOpen:
+          (action.props.openOnFocus || Boolean(state.query)) &&
+          action.props.shouldPanelOpen({ state }),
       };
     }
 


### PR DESCRIPTION
## Description

This improves the experience when using `openOnFocus` on slow networks. The panel only opens when `shouldPanelOpen` returns `true`.

The default implementation for `shouldPanelOpen` is to return `true` when there are some items. As a result, the panel won't open on focus as long as there's no results. This means that the panel won't open with empty content.

## Preview

### Before

![ac-onFocus-without-shouldPanelOpen](https://user-images.githubusercontent.com/6137112/108488878-2cb08880-72a1-11eb-96aa-38a37e890f38.gif)

### After

![ac-onFocus-with-shouldPanelOpen](https://user-images.githubusercontent.com/6137112/108488867-2a4e2e80-72a1-11eb-93b5-1e1a48cc974d.gif)

