### PR TITLE
feat(js): scroll to top when query changes

### DIFF
--- a/packages/autocomplete-js/src/autocomplete.ts
+++ b/packages/autocomplete-js/src/autocomplete.ts
@@ -223,6 +223,17 @@ export function autocomplete<TItem extends BaseItem>(
         setPanelPosition();
       }
 
+      // We scroll to the top of the panel whenever the query changes (i.e. new
+      // results come in) so that users don't have to.
+      const scrollablePanel = document.querySelector('.aa-Panel--Scrollable');
+      if (
+        scrollablePanel &&
+        scrollablePanel.scrollTop !== 0 &&
+        state.query !== prevState.query
+      ) {
+        scrollablePanel.scrollTop = 0;
+      }
+
       debouncedRender({ state });
     };
 

--- a/packages/autocomplete-js/src/autocomplete.ts
+++ b/packages/autocomplete-js/src/autocomplete.ts
@@ -225,13 +225,15 @@ export function autocomplete<TItem extends BaseItem>(
 
       // We scroll to the top of the panel whenever the query changes (i.e. new
       // results come in) so that users don't have to.
-      const scrollablePanel = document.querySelector('.aa-Panel--Scrollable');
-      if (
-        scrollablePanel &&
-        scrollablePanel.scrollTop !== 0 &&
-        state.query !== prevState.query
-      ) {
-        scrollablePanel.scrollTop = 0;
+      if (state.query !== prevState.query) {
+        const scrollablePanels = document.querySelectorAll(
+          '.aa-Panel--Scrollable'
+        );
+        scrollablePanels.forEach((scrollablePanel) => {
+          if (scrollablePanel.scrollTop !== 0) {
+            scrollablePanel.scrollTop = 0;
+          }
+        });
       }
 
       debouncedRender({ state });

--- a/packages/autocomplete-js/src/render.tsx
+++ b/packages/autocomplete-js/src/render.tsx
@@ -165,7 +165,9 @@ export function renderPanel<TItem extends BaseItem>(
     </section>
   ));
 
-  const children = <div className="aa-PanelLayout">{sections}</div>;
+  const children = (
+    <div className="aa-PanelLayout aa-Panel--Scrollable">{sections}</div>
+  );
 
   render({ children, state, sections, createElement, Fragment }, dom.panel);
 }

--- a/packages/autocomplete-theme-classic/src/theme.scss
+++ b/packages/autocomplete-theme-classic/src/theme.scss
@@ -203,7 +203,6 @@ body {
     height: 100%;
     margin-top: var(--aa-spacing-half);
     max-height: var(--aa-panel-max-height);
-    overflow-y: auto;
     padding-bottom: var(--aa-spacing-half);
     padding-top: var(--aa-spacing-half);
     position: relative;
@@ -220,6 +219,9 @@ body {
       max-width: 50%;
       overflow: hidden;
     }
+  }
+  .aa-Panel--Scrollable {
+    overflow-y: auto;
   }
 
   // when a query isn't resolved yet

--- a/packages/website/docs/autocomplete-theme-classic.md
+++ b/packages/website/docs/autocomplete-theme-classic.md
@@ -155,8 +155,9 @@ autocomplete({
 
 ## CSS utility classes
 
-- `aa-ActiveOnly`: displays an element only when the item is active
-- `aa-TouchOnly`: displays an element only on touch devices.
+- `.aa-Panel--Scrollable`: declares the scrollable container of the panel
+- `.aa-ActiveOnly`: displays an element only when the item is active
+- `.aa-TouchOnly`: displays an element only on touch devices.
 
 ## Dark mode
 


### PR DESCRIPTION
## Description

This scrolls to the top of the panel when the query changes (i.e., when new results come in) so that users don't have to.

## How

We introduce a new CSS utility class in the theme called `.aa-Panel--Scrollable` which hints Autocomplete that this is the container responsible for displaying the list of items.

By default, this CSS class is attached to `.aa-PanelLayout`, but when we introduce the Preview Panel plugin, it will be attached to the left child of `.aa-PanelLayout`.

Whenever the query changes, we scroll to the top of this scrollable container.

## Preview

### Before

![ac-scrolltop-query-change-before](https://user-images.githubusercontent.com/6137112/108496761-cfb9d000-72aa-11eb-9ed2-2424ba0ceb7f.gif)

### After

![ac-scrolltop-query-change-after](https://user-images.githubusercontent.com/6137112/108496728-c2044a80-72aa-11eb-80f7-123dd71cd7ef.gif)
