### PR TITLE
docs(renderer): add usage warning

### DIFF
--- a/packages/website/docs/creating-a-renderer.md
+++ b/packages/website/docs/creating-a-renderer.md
@@ -3,7 +3,13 @@ id: creating-a-renderer
 title: Creating a Renderer
 ---
 
-Learn how to build an autocomplete UI using React.
+Learn how to build an autocomplete UI from the ground up, focusing React.
+
+:::info
+
+This is an advanced guide that leverages the [`autocomplete-core`](createAutocomplete) package. You shouldn't need to use it if you haven't reached limitations with [`autocomplete-js`](autocomplete-js).
+
+:::
 
 The [`autocomplete-js`](autocomplete-js) package includes everything you need to render a JavaScript autocomplete experience that you can bind to [your own framework](autocomplete-js#renderer). If you want to build a custom UI that differs from the `autocomplete-js` output, for example in [React](https://reactjs.org/docs/getting-started.html) or another front-end framework, the [`autocomplete-core`](createAutocomplete) package provides all the primitives to build it.
 
@@ -80,6 +86,7 @@ function Autocomplete() {
 ```
 
 Note the following commented portions:
+
 - (1) You can leverage a React state for the autocomplete component to re-render when the [Autocomplete state](state) changes.
 - (2) You can listen to all Autocomplete state changes to synchronize them with the React state.
 - (3) This example uses an Algolia index as a [source](sources).

--- a/packages/website/docs/creating-a-renderer.md
+++ b/packages/website/docs/creating-a-renderer.md
@@ -5,15 +5,15 @@ title: Creating a custom Renderer
 
 Learn how to build a full autocomplete UI from the ground up.
 
+The [`autocomplete-js`](autocomplete-js) package includes everything you need to render a JavaScript autocomplete experience that you can bind to [your own framework](autocomplete-js#renderer). If you want to build a custom UI that differs from the `autocomplete-js` output, for example in [React](https://reactjs.org/docs/getting-started.html) or another front-end framework, the [`autocomplete-core`](createAutocomplete) package provides all the primitives to build it.
+
+This guide shows how to leverage all the autocomplete capacities to build an accessible autocomplete, both for desktop and mobile, with React. You can find the final result in [this sandbox](https://codesandbox.io/s/github/algolia/autocomplete.js/tree/next/examples/react-renderer?file=/src/Autocomplete.tsx).
+
 :::info You might not need a custom renderer
 
 Building a custom renderer is an advanced pattern that leverages the [`autocomplete-core`](createAutocomplete) package to fully control the rendered experience. You shouldn't need to use it unless you've reached limitations with [`autocomplete-js`](autocomplete-js) and it's templating capabilities.
 
 :::
-
-The [`autocomplete-js`](autocomplete-js) package includes everything you need to render a JavaScript autocomplete experience that you can bind to [your own framework](autocomplete-js#renderer). If you want to build a custom UI that differs from the `autocomplete-js` output, for example in [React](https://reactjs.org/docs/getting-started.html) or another front-end framework, the [`autocomplete-core`](createAutocomplete) package provides all the primitives to build it.
-
-This guide shows how to leverage all the autocomplete capacities to build an accessible autocomplete, both for desktop and mobile, with React. You can find the final result in [this sandbox](https://codesandbox.io/s/github/algolia/autocomplete.js/tree/next/examples/react-renderer?file=/src/Autocomplete.tsx).
 
 ## Importing the package
 

--- a/packages/website/docs/creating-a-renderer.md
+++ b/packages/website/docs/creating-a-renderer.md
@@ -1,6 +1,6 @@
 ---
 id: creating-a-renderer
-title: Creating a custom Renderer
+title: Creating a custom renderer
 ---
 
 Learn how to build a full autocomplete UI from the ground up.

--- a/packages/website/docs/creating-a-renderer.md
+++ b/packages/website/docs/creating-a-renderer.md
@@ -1,13 +1,13 @@
 ---
 id: creating-a-renderer
-title: Creating a Renderer
+title: Creating a custom Renderer
 ---
 
-Learn how to build an autocomplete UI from the ground up, focusing React.
+Learn how to build a full autocomplete UI from the ground up.
 
-:::info
+:::info You might not need a custom renderer
 
-This is an advanced guide that leverages the [`autocomplete-core`](createAutocomplete) package. You shouldn't need to use it if you haven't reached limitations with [`autocomplete-js`](autocomplete-js).
+Building a custom renderer is an advanced pattern that leverages the [`autocomplete-core`](createAutocomplete) package to fully control the rendered experience. You shouldn't need to use it unless you've reached limitations with [`autocomplete-js`](autocomplete-js) and it's templating capabilities.
 
 :::
 


### PR DESCRIPTION
Some people get confused why this guide seem complex compared to using Preact. It's because it's relying on `autocomplete-core` to create your own Autocomplete Renderer, which you shouldn't need if you haven't hit limitations with Autocomplete JS.