### PR TITLE
docs: differentiate core vs js

### DIFF
--- a/packages/website/docs/getting-started.mdx
+++ b/packages/website/docs/getting-started.mdx
@@ -26,9 +26,9 @@ Keep reading to see how to install Autocomplete and build a basic implementation
 
 ## Installation
 
-The recommended way to get started is with the [`autocomplete-js`](autocomplete-js) package. It includes everything you need to render a JavaScript autocomplete experience.
+The recommended way to get started is with the [`autocomplete-js`](autocomplete-js) package. It includes everything you need to render a JavaScript autocomplete experience. You can use it with [React](using-react), [Vue](using-vue), and other front-end frameworks.
 
-Otherwise, you can install the [`autocomplete-core`](createAutocomplete) package if you want to [build a renderer](creating-a-renderer) from scratch.
+If you're unable to create the experience you want using [`autocomplete-js`](autocomplete-js), you can use the primitives exposed in [`autocomplete-core`](createAutocomplete) to [build a custom renderer](creating-a-renderer).
 
 All Autocomplete packages are available on the [npm](https://www.npmjs.com/) registry.
 


### PR DESCRIPTION
This PR attempts to better differentiate when you need `autocomplete-js` and `autocomplete-core` in the getting started page.

I wonder if it may be best to actually just remove mention of `core` here, since I imagine very few users will need this, and it could cause confusion for most users.

If we want to keep it, could you help had clear use cases to the second paragraph @francoischalifour ? My current language (unable to create the experience you want) is still too vague.
