### PR TITLE
docs: remove API from top nav

### DIFF
--- a/packages/website/docusaurus.config.js
+++ b/packages/website/docusaurus.config.js
@@ -21,11 +21,6 @@ module.exports = {
           position: 'right',
         },
         {
-          label: 'API',
-          to: 'docs/api',
-          position: 'right',
-        },
-        {
           label: 'Playground',
           to:
             'https://codesandbox.io/s/github/algolia/autocomplete/tree/next/examples/js?file=/app.tsx',


### PR DESCRIPTION
This PR removes the "API" link from the top nav, per user feedback.