### PR TITLE
docs(getAlgoliaResults): rewrite guides

### DIFF
--- a/packages/website/docs/getAlgoliaResults-js.md
+++ b/packages/website/docs/getAlgoliaResults-js.md
@@ -38,4 +38,4 @@ getAlgoliaResults({
 
 ## Parameters
 
-See [`autocomplete-preset-algolia#getAlgoliaResults`](getAlgoliaResults#params).
+See [`autocomplete-preset-algolia#getAlgoliaResults`](getAlgoliaResults#parameters).

--- a/packages/website/docs/getAlgoliaResults-js.md
+++ b/packages/website/docs/getAlgoliaResults-js.md
@@ -3,15 +3,22 @@ id: getAlgoliaResults-js
 title: getAlgoliaResults
 ---
 
-Retrieves Algolia results from multiple indices.
+import GetAlgoliaResultsIntro from './partials/preset-algolia/getAlgoliaResults/intro.md'
+
+<GetAlgoliaResultsIntro />
 
 ## Example
+
+This example uses the function along with the [`algoliasearch`](https://www.npmjs.com/package/algoliasearch) API client.
 
 ```js
 import { getAlgoliaResults } from '@algolia/autocomplete-js';
 import algoliasearch from 'algoliasearch/lite';
 
-const searchClient = algoliasearch(APP_ID, SEARCH_API_KEY);
+const searchClient = algoliasearch(
+  'latency',
+  '6be0576ff61c053d5f9a3225e2a90f76'
+);
 
 getAlgoliaResults({
   searchClient,
@@ -29,6 +36,6 @@ getAlgoliaResults({
 });
 ```
 
-## Params
+## Parameters
 
 See [`autocomplete-preset-algolia#getAlgoliaResults`](getAlgoliaResults#params).

--- a/packages/website/docs/getAlgoliaResults.md
+++ b/packages/website/docs/getAlgoliaResults.md
@@ -3,8 +3,11 @@ id: getAlgoliaResults
 ---
 
 import GetAlgoliaResultsIntro from './partials/preset-algolia/getAlgoliaResults/intro.md'
+import PresetAlgoliaNote from './partials/preset-algolia/note.md'
 
 <GetAlgoliaResultsIntro />
+
+<PresetAlgoliaNote />
 
 ## Installation
 
@@ -65,11 +68,17 @@ getAlgoliaResults({
 
 The initialized Algolia search client.
 
+### `queries`
+
+> `MultipleQueriesQuery[]` | required
+
+The queries to perform, with the following parameters:
+
 #### `indexName`
 
 > `string` | required
 
-The index name.
+The index name to search into.
 
 #### `query`
 

--- a/packages/website/docs/getAlgoliaResults.md
+++ b/packages/website/docs/getAlgoliaResults.md
@@ -82,13 +82,13 @@ The index name to search into.
 
 #### `query`
 
-> `string` | required
+> `string`
 
 The query to search for.
 
 #### `params`
 
-> [`SearchParameters`](https://www.algolia.com/doc/api-reference/search-api-parameters/) | required
+> [`SearchParameters`](https://www.algolia.com/doc/api-reference/search-api-parameters/)
 
 Algolia search parameters.
 

--- a/packages/website/docs/getAlgoliaResults.md
+++ b/packages/website/docs/getAlgoliaResults.md
@@ -11,7 +11,7 @@ import PresetAlgoliaNote from './partials/preset-algolia/note.md'
 
 ## Installation
 
-First, you need to install the plugin.
+First, you need to install the preset.
 
 ```bash
 yarn add @algolia/autocomplete-preset-algolia@alpha

--- a/packages/website/docs/getAlgoliaResults.md
+++ b/packages/website/docs/getAlgoliaResults.md
@@ -2,15 +2,44 @@
 id: getAlgoliaResults
 ---
 
-Retrieves Algolia results from multiple indices.
+import GetAlgoliaResultsIntro from './partials/preset-algolia/getAlgoliaResults/intro.md'
+
+<GetAlgoliaResultsIntro />
+
+## Installation
+
+First, you need to install the plugin.
+
+```bash
+yarn add @algolia/autocomplete-preset-algolia@alpha
+# or
+npm install @algolia/autocomplete-preset-algolia@alpha
+```
+
+Then import it in your project:
+
+```js
+import { getAlgoliaResults } from '@algolia/autocomplete-preset-algolia';
+```
+
+If you don't use a package manager, you can use a standalone endpoint:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-preset-algolia@alpha"></script>
+```
 
 ## Example
+
+This example uses the function along with the [`algoliasearch`](https://www.npmjs.com/package/algoliasearch) API client.
 
 ```js
 import { getAlgoliaResults } from '@algolia/autocomplete-preset-algolia';
 import algoliasearch from 'algoliasearch/lite';
 
-const searchClient = algoliasearch(APP_ID, SEARCH_API_KEY);
+const searchClient = algoliasearch(
+  'latency',
+  '6be0576ff61c053d5f9a3225e2a90f76'
+);
 
 getAlgoliaResults({
   searchClient,
@@ -28,27 +57,33 @@ getAlgoliaResults({
 });
 ```
 
-## Params
+## Parameters
 
 ### `searchClient`
 
 > `SearchClient` | required
 
-### `queries`
+The initialized Algolia search client.
 
 #### `indexName`
 
 > `string` | required
 
+The index name.
+
 #### `query`
 
 > `string` | required
+
+The query to search for.
 
 #### `params`
 
 > [`SearchParameters`](https://www.algolia.com/doc/api-reference/search-api-parameters/) | required
 
-Default search parameters:
+Algolia search parameters.
+
+These are the default search parameters. You can leave them as is and specify other parameters, or override them.
 
 ```json
 {
@@ -60,7 +95,7 @@ Default search parameters:
 
 ## Returns
 
-It returns a promise of the following schema:
+The function returns a promise that resolves to a response with the following schema:
 
 ```json
 {

--- a/packages/website/docs/partials/preset-algolia/getAlgoliaResults/intro.md
+++ b/packages/website/docs/partials/preset-algolia/getAlgoliaResults/intro.md
@@ -1,0 +1,1 @@
+Retrieves Algolia results from multiple indices as arrays of records.

--- a/packages/website/docs/partials/preset-algolia/getAlgoliaResults/intro.md
+++ b/packages/website/docs/partials/preset-algolia/getAlgoliaResults/intro.md
@@ -1,1 +1,1 @@
-Retrieves Algolia results from multiple indices as arrays of records.
+Retrieves Algolia results from multiple indices.

--- a/packages/website/docs/partials/preset-algolia/getAlgoliaResults/intro.md
+++ b/packages/website/docs/partials/preset-algolia/getAlgoliaResults/intro.md
@@ -1,1 +1,3 @@
 Retrieves Algolia results from multiple indices.
+
+The `getAlgoliaResults` function lets you query several Algolia indices at once.

--- a/packages/website/docs/partials/preset-algolia/note.md
+++ b/packages/website/docs/partials/preset-algolia/note.md
@@ -1,0 +1,5 @@
+:::note
+
+If you're using [`autocomplete-js`](/docs/autocomplete-js), all Algolia utilities are available directly in the package with the right user agents and the virtual DOM layer. **You don't need to import the preset separately.**
+
+:::


### PR DESCRIPTION
This rewrites the `getAlgoliaResults` docs for both `autocomplete-preset-algolia` and `algolia-js`.