### PR TITLE
docs(getAlgoliaFacetHits): rewrite guides

### DIFF
--- a/packages/website/docs/getAlgoliaFacetHits-js.md
+++ b/packages/website/docs/getAlgoliaFacetHits-js.md
@@ -3,7 +3,9 @@ id: getAlgoliaFacetHits-js
 title: getAlgoliaFacetHits
 ---
 
-Retrieves Algolia facet hits from multiple indices.
+import GetAlgoliaFacetHitsIntro from './partials/preset-algolia/getAlgoliaFacetHits/intro.md'
+
+<GetAlgoliaFacetHitsIntro />
 
 ## Example
 
@@ -11,7 +13,10 @@ Retrieves Algolia facet hits from multiple indices.
 import { getAlgoliaFacetHits } from '@algolia/autocomplete-js';
 import algoliasearch from 'algoliasearch/lite';
 
-const searchClient = algoliasearch(APP_ID, SEARCH_API_KEY);
+const searchClient = algoliasearch(
+  'latency',
+  '6be0576ff61c053d5f9a3225e2a90f76'
+);
 
 getAlgoliaFacetHits({
   searchClient,
@@ -30,6 +35,6 @@ getAlgoliaFacetHits({
 });
 ```
 
-## Params
+## Parameters
 
 See [`autocomplete-preset-algolia#getAlgoliaFacetHits`](getAlgoliaFacetHits#params).

--- a/packages/website/docs/getAlgoliaFacetHits-js.md
+++ b/packages/website/docs/getAlgoliaFacetHits-js.md
@@ -37,4 +37,4 @@ getAlgoliaFacetHits({
 
 ## Parameters
 
-See [`autocomplete-preset-algolia#getAlgoliaFacetHits`](getAlgoliaFacetHits#params).
+See [`autocomplete-preset-algolia#getAlgoliaFacetHits`](getAlgoliaFacetHits#parameters).

--- a/packages/website/docs/getAlgoliaFacetHits.md
+++ b/packages/website/docs/getAlgoliaFacetHits.md
@@ -87,6 +87,12 @@ Algolia search for facet values parameters.
 
 These are the default parameters. You can leave them as is and specify other parameters, or override them.
 
+:::info
+
+If you override `highlightPreTag` and `highlightPostTag`, you won't be able to use the built-in highlighting utilities such as [`highlightHit`](highlightHit).
+
+:::
+
 ```json
 {
   "highlightPreTag": "__aa-highlight__",

--- a/packages/website/docs/getAlgoliaFacetHits.md
+++ b/packages/website/docs/getAlgoliaFacetHits.md
@@ -3,8 +3,11 @@ id: getAlgoliaFacetHits
 ---
 
 import GetAlgoliaFacetHitsIntro from './partials/preset-algolia/getAlgoliaFacetHits/intro.md'
+import PresetAlgoliaNote from './partials/preset-algolia/note.md'
 
 <GetAlgoliaFacetHitsIntro />
+
+<PresetAlgoliaNote />
 
 ## Installation
 
@@ -66,7 +69,7 @@ The initialized Algolia search client.
 
 ### `queries`
 
-> `MultipleQueriesQuery[]` | required
+> `FacetQuery[]` | required
 
 The queries to search for, with the following parameters:
 
@@ -78,11 +81,11 @@ The index name.
 
 #### `params`
 
-> [`SearchParameters`](https://www.algolia.com/doc/api-reference/search-api-parameters/) & [`Request Options`](https://www.algolia.com/doc/api-client/getting-started/request-options/) | required
+> [`SearchForFacetValuesQueryParams` & `SearchOptions`](https://www.algolia.com/doc/api-reference/api-methods/search-for-facet-values/#parameters) | required
 
-Algolia search parameters and request options.
+Algolia search for facet values parameters.
 
-These are the default search parameters. You can leave them as is and specify other parameters, or override them.
+These are the default parameters. You can leave them as is and specify other parameters, or override them.
 
 ```json
 {

--- a/packages/website/docs/getAlgoliaFacetHits.md
+++ b/packages/website/docs/getAlgoliaFacetHits.md
@@ -2,7 +2,31 @@
 id: getAlgoliaFacetHits
 ---
 
-Retrieves Algolia facet hits from multiple indices.
+import GetAlgoliaFacetHitsIntro from './partials/preset-algolia/getAlgoliaFacetHits/intro.md'
+
+<GetAlgoliaFacetHitsIntro />
+
+## Installation
+
+First, you need to install the plugin.
+
+```bash
+yarn add @algolia/autocomplete-preset-algolia@alpha
+# or
+npm install @algolia/autocomplete-preset-algolia@alpha
+```
+
+Then import it in your project:
+
+```js
+import { getAlgoliaFacetHits } from '@algolia/autocomplete-preset-algolia';
+```
+
+If you don't use a package manager, you can use a standalone endpoint:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-preset-algolia@alpha"></script>
+```
 
 ## Example
 
@@ -10,7 +34,10 @@ Retrieves Algolia facet hits from multiple indices.
 import { getAlgoliaFacetHits } from '@algolia/autocomplete-preset-algolia';
 import algoliasearch from 'algoliasearch/lite';
 
-const searchClient = algoliasearch(APP_ID, SEARCH_API_KEY);
+const searchClient = algoliasearch(
+  'latency',
+  '6be0576ff61c053d5f9a3225e2a90f76'
+);
 
 getAlgoliaFacetHits({
   searchClient,
@@ -29,23 +56,33 @@ getAlgoliaFacetHits({
 });
 ```
 
-## Params
+## Parameters
 
 ### `searchClient`
 
 > `SearchClient` | required
 
+The initialized Algolia search client.
+
 ### `queries`
+
+> `MultipleQueriesQuery[]` | required
+
+The queries to search for, with the following parameters:
 
 #### `indexName`
 
 > `string` | required
 
+The index name.
+
 #### `params`
 
 > [`SearchParameters`](https://www.algolia.com/doc/api-reference/search-api-parameters/) & [`Request Options`](https://www.algolia.com/doc/api-client/getting-started/request-options/) | required
 
-Default search parameters:
+Algolia search parameters and request options.
+
+These are the default search parameters. You can leave them as is and specify other parameters, or override them.
 
 ```json
 {
@@ -56,7 +93,7 @@ Default search parameters:
 
 ## Returns
 
-It returns a promise of the following schema:
+The function returns a promise that resolves to a response with the following schema:
 
 ```json
 [

--- a/packages/website/docs/getAlgoliaFacetHits.md
+++ b/packages/website/docs/getAlgoliaFacetHits.md
@@ -81,7 +81,7 @@ The index name.
 
 #### `params`
 
-> [`SearchForFacetValuesQueryParams` & `SearchOptions`](https://www.algolia.com/doc/api-reference/api-methods/search-for-facet-values/#parameters) | required
+> [`SearchForFacetValuesQueryParams` & `SearchOptions`](https://www.algolia.com/doc/api-reference/api-methods/search-for-facet-values/#parameters)
 
 Algolia search for facet values parameters.
 

--- a/packages/website/docs/getAlgoliaFacetHits.md
+++ b/packages/website/docs/getAlgoliaFacetHits.md
@@ -11,7 +11,7 @@ import PresetAlgoliaNote from './partials/preset-algolia/note.md'
 
 ## Installation
 
-First, you need to install the plugin.
+First, you need to install the preset.
 
 ```bash
 yarn add @algolia/autocomplete-preset-algolia@alpha

--- a/packages/website/docs/partials/preset-algolia/getAlgoliaFacetHits/intro.md
+++ b/packages/website/docs/partials/preset-algolia/getAlgoliaFacetHits/intro.md
@@ -1,1 +1,3 @@
 Retrieves Algolia facet hits from multiple indices.
+
+The `getAlgoliaFacetHits` function lets you query facet hits several Algolia indices at once.

--- a/packages/website/docs/partials/preset-algolia/getAlgoliaFacetHits/intro.md
+++ b/packages/website/docs/partials/preset-algolia/getAlgoliaFacetHits/intro.md
@@ -1,0 +1,1 @@
+Retrieves Algolia facet hits from multiple indices.

--- a/packages/website/docs/partials/preset-algolia/note.md
+++ b/packages/website/docs/partials/preset-algolia/note.md
@@ -1,0 +1,5 @@
+:::note
+
+If you're using [`autocomplete-js`](/docs/autocomplete-js), all Algolia utilities are available directly in the package with the right user agents and the virtual DOM layer. **You don't need to import the preset separately.**
+
+:::


### PR DESCRIPTION
This rewrites the `getAlgoliaFacetHits` docs for both `autocomplete-preset-algolia` and `algolia-js`.