### PR TITLE
docs(autocomplete-preset-algolia): add common note

### DIFF
--- a/packages/website/docs/partials/preset-algolia/note.md
+++ b/packages/website/docs/partials/preset-algolia/note.md
@@ -1,0 +1,5 @@
+:::note
+
+If you're using [`autocomplete-js`](/docs/autocomplete-js), all Algolia utilities are available directly in the package with the right user agents and the virtual DOM layer. **You don't need to import the preset separately.**
+
+:::


### PR DESCRIPTION
This adds a common note for all functions under `autocomplete-preset-algolia`.