### PR TITLE
docs(parseAlgoliaHitHighlight): rewrite guides

### DIFF
--- a/packages/website/docs/highlightHit.md
+++ b/packages/website/docs/highlightHit.md
@@ -4,12 +4,14 @@ id: highlightHit
 
 Returns a virtual node with highlighted matching parts of an Algolia hit.
 
-## Example with a single string
+## Examples
+
+### With a single string
 
 ```js
 import { highlightHit } from '@algolia/autocomplete-js';
 
-// fetch an Algolia hit
+// An Algolia hit for query "he"
 const hit = {
   query: 'Hello there',
   _highlightResult: {
@@ -25,12 +27,12 @@ const highlightedValue = highlightHit({
 });
 ```
 
-## Example with nested attributes
+### With nested attributes
 
 ```js
 import { highlightHit } from '@algolia/autocomplete-js';
 
-// fetch an Algolia hit
+// An Algolia hit for query "he"
 const hit = {
   query: {
     title: 'Hello there',
@@ -50,22 +52,28 @@ const highlightedValue = highlightHit({
 });
 ```
 
-## Params
+## Parameters
 
 ### `hit`
 
 > `AlgoliaHit` | required
 
-The Algolia hit to retrieve the attribute value from.
+The Algolia hit whose attribute to retrieve the highlighted parts from.
 
 ### `attribute`
 
 > `string | string[]` | required
 
-The attribute to retrieve the highlight value from. You can use the array syntax to reference the nested attributes.
+The attribute to retrieve the highlighted parts from. You can use the array syntax to reference nested attributes.
 
 ### `tagName`
 
 > `string` | defaults to `mark`
 
 The tag name of the virtual node.
+
+## Returns
+
+> `HighlightItemParams<THit>`
+
+A virtual node with the highlighted matching parts.

--- a/packages/website/docs/highlightHit.md
+++ b/packages/website/docs/highlightHit.md
@@ -4,9 +4,13 @@ id: highlightHit
 
 Returns a virtual node with highlighted matching parts of an Algolia hit.
 
+The `highlightHit` function lets you turn an Algolia hit into a virtual node with highlighted matching parts for a given attribute.
+
 ## Examples
 
 ### With a single string
+
+To determine what attribute to parse, you can pass it as a string.
 
 ```js
 import { highlightHit } from '@algolia/autocomplete-js';
@@ -28,6 +32,8 @@ const highlightedValue = highlightHit({
 ```
 
 ### With nested attributes
+
+If you're referencing a nested attribute, you can use the array syntax.
 
 ```js
 import { highlightHit } from '@algolia/autocomplete-js';

--- a/packages/website/docs/highlightHit.md
+++ b/packages/website/docs/highlightHit.md
@@ -82,4 +82,4 @@ The tag name of the virtual node.
 
 > `HighlightItemParams<THit>`
 
-A virtual node with the highlighted matching parts.
+Virtual nodes with the highlighted matching parts.

--- a/packages/website/docs/highlightHit.md
+++ b/packages/website/docs/highlightHit.md
@@ -15,13 +15,13 @@ To determine what attribute to parse, you can pass it as a string.
 ```js
 import { highlightHit } from '@algolia/autocomplete-js';
 
-// An Algolia hit for query "he"
+// An Algolia hit for query "the"
 const hit = {
-  query: 'Hello there',
+  name: 'The Legend of Zelda: Breath of the Wild',
   _highlightResult: {
-    query: {
+    name: {
       value:
-        '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+        '__aa-highlight__The__/aa-highlight__ Legend of Zelda: Breath of __aa-highlight__the__/aa-highlight__ Wild',
     },
   },
 };
@@ -38,23 +38,23 @@ If you're referencing a nested attribute, you can use the array syntax.
 ```js
 import { highlightHit } from '@algolia/autocomplete-js';
 
-// An Algolia hit for query "he"
+// An Algolia hit for query "cam"
 const hit = {
-  query: {
-    title: 'Hello there',
+  hierarchicalCategories: {
+    lvl1: 'Cameras & Camcoders',
   }
   _highlightResult: {
-    query: {
-      title: {
+    hierarchicalCategories: {
+      lvl1: {
         value:
-          '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+          '__aa-highlight__Cam__/aa-highlight__eras & __aa-highlight__Cam__/aa-highlight__coders',
       },
     },
   },
 };
 const highlightedValue = highlightHit({
   hit,
-  attribute: ['query', 'title'],
+  attribute: ['hierarchicalCategories', 'lvl1'],
 });
 ```
 

--- a/packages/website/docs/parseAlgoliaHitHighlight.md
+++ b/packages/website/docs/parseAlgoliaHitHighlight.md
@@ -12,7 +12,7 @@ The `parseAlgoliaHitHighlight` function lets you parse the highlighted parts of 
 
 ## Installation
 
-First, you need to install the plugin.
+First, you need to install the preset.
 
 ```bash
 yarn add @algolia/autocomplete-preset-algolia@alpha

--- a/packages/website/docs/parseAlgoliaHitHighlight.md
+++ b/packages/website/docs/parseAlgoliaHitHighlight.md
@@ -46,7 +46,7 @@ const hit = {
     },
   },
 };
-const snippetParts = parseAlgoliaHitHighlight({
+const highlightedParts = parseAlgoliaHitHighlight({
   hit,
   attribute: 'name',
 });
@@ -72,7 +72,7 @@ const hit = {
     },
   },
 };
-const snippetParts = parseAlgoliaHitHighlight({
+const highlightedParts = parseAlgoliaHitHighlight({
   hit,
   attribute: ['name', 'type'],
 });

--- a/packages/website/docs/parseAlgoliaHitHighlight.md
+++ b/packages/website/docs/parseAlgoliaHitHighlight.md
@@ -6,6 +6,8 @@ import PresetAlgoliaNote from './partials/preset-algolia/note.md'
 
 Returns the highlighted parts of an Algolia hit.
 
+The `parseAlgoliaHitHighlight` function lets you parse the highlighted parts of an Algolia hit.
+
 <PresetAlgoliaNote />
 
 ## Installation

--- a/packages/website/docs/parseAlgoliaHitHighlight.md
+++ b/packages/website/docs/parseAlgoliaHitHighlight.md
@@ -2,14 +2,42 @@
 id: parseAlgoliaHitHighlight
 ---
 
+import PresetAlgoliaNote from './partials/preset-algolia/note.md'
+
 Returns the highlighted parts of an Algolia hit.
 
-## Example with a single string
+<PresetAlgoliaNote />
+
+## Installation
+
+First, you need to install the plugin.
+
+```bash
+yarn add @algolia/autocomplete-preset-algolia@alpha
+# or
+npm install @algolia/autocomplete-preset-algolia@alpha
+```
+
+Then import it in your project:
+
+```js
+import { parseAlgoliaHitHighlight } from '@algolia/autocomplete-preset-algolia';
+```
+
+If you don't use a package manager, you can use a standalone endpoint:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-preset-algolia@alpha"></script>
+```
+
+## Examples
+
+### With a single string
 
 ```js
 import { parseAlgoliaHitHighlight } from '@algolia/autocomplete-preset-algolia';
 
-// Fetch an Algolia hit
+// An Algolia hit for query "lap"
 const hit = {
   name: 'Laptop',
   _highlightResult: {
@@ -23,15 +51,15 @@ const snippetParts = parseAlgoliaHitHighlight({
   attribute: 'name',
 });
 
-// => [{ value: 'Lap', isHighlighted: true }, { value: 'top', isHighlighted: false }]
+// [{ value: 'Lap', isHighlighted: true }, { value: 'top', isHighlighted: false }]
 ```
 
-## Example with nested attributes
+### With nested attributes
 
 ```js
 import { parseAlgoliaHitHighlight } from '@algolia/autocomplete-preset-algolia';
 
-// Fetch an Algolia hit
+// An Algolia hit for query "lap"
 const hit = {
   name: {
     type: 'Laptop',
@@ -49,19 +77,25 @@ const snippetParts = parseAlgoliaHitHighlight({
   attribute: ['name', 'type'],
 });
 
-// => [{ value: 'Lap', isHighlighted: true }, { value: 'top', isHighlighted: false }]
+// [{ value: 'Lap', isHighlighted: true }, { value: 'top', isHighlighted: false }]
 ```
 
-## Params
+## Parameters
 
 ### `hit`
 
 > `AlgoliaHit` | required
 
-The Algolia hit to retrieve the attribute value from.
+The Algolia hit whose attribute to retrieve the highlighted parts from.
 
 ### `attribute`
 
 > `string | string[]` | required
 
-The attribute to retrieve the reverse highlight value from. You can use the array syntax to reference the nested attributes.
+The attribute to retrieve the highlighted parts from. You can use the array syntax to reference nested attributes.
+
+## Returns
+
+> `ParsedAttribute[]`
+
+An array of the parsed attribute's parts.

--- a/packages/website/docs/partials/preset-algolia/note.md
+++ b/packages/website/docs/partials/preset-algolia/note.md
@@ -1,0 +1,5 @@
+:::note
+
+If you're using [`autocomplete-js`](/docs/autocomplete-js), all Algolia utilities are available directly in the package with the right user agents and the virtual DOM layer. **You don't need to import the preset separately.**
+
+:::


### PR DESCRIPTION
This rewrites the `parseAlgoliaHitHighlight` docs for `autocomplete-preset-algolia` and `highlightHit` for `algolia-js`.