### PR TITLE
docs(parseAlgoliaHitReverseHighlight): rewrite guides

### DIFF
--- a/packages/website/docs/parseAlgoliaHitReverseHighlight.md
+++ b/packages/website/docs/parseAlgoliaHitReverseHighlight.md
@@ -48,7 +48,7 @@ const hit = {
     },
   },
 };
-const snippetParts = parseAlgoliaHitReverseHighlight({
+const highlightedParts = parseAlgoliaHitReverseHighlight({
   hit,
   attribute: 'name',
 });
@@ -74,7 +74,7 @@ const hit = {
     },
   },
 };
-const snippetParts = parseAlgoliaHitReverseHighlight({
+const highlightedParts = parseAlgoliaHitReverseHighlight({
   hit,
   attribute: ['name', 'type'],
 });

--- a/packages/website/docs/parseAlgoliaHitReverseHighlight.md
+++ b/packages/website/docs/parseAlgoliaHitReverseHighlight.md
@@ -12,7 +12,7 @@ The `parseAlgoliaHitReverseHighlight` function lets you parse the non-highlighte
 
 ## Installation
 
-First, you need to install the plugin.
+First, you need to install the preset.
 
 ```bash
 yarn add @algolia/autocomplete-preset-algolia@alpha

--- a/packages/website/docs/parseAlgoliaHitReverseHighlight.md
+++ b/packages/website/docs/parseAlgoliaHitReverseHighlight.md
@@ -88,13 +88,13 @@ const highlightedParts = parseAlgoliaHitReverseHighlight({
 
 > `AlgoliaHit` | required
 
-The Algolia hit whose attribute to retrieve the highlighted parts from.
+The Algolia hit whose attribute to retrieve the reverse highlighted parts from.
 
 ### `attribute`
 
 > `string | string[]` | required
 
-The attribute to retrieve the highlighted parts from. You can use the array syntax to reference nested attributes.
+The attribute to retrieve the reverse highlighted parts from. You can use the array syntax to reference nested attributes.
 
 ## Returns
 

--- a/packages/website/docs/parseAlgoliaHitReverseHighlight.md
+++ b/packages/website/docs/parseAlgoliaHitReverseHighlight.md
@@ -2,16 +2,44 @@
 id: parseAlgoliaHitReverseHighlight
 ---
 
+import PresetAlgoliaNote from './partials/preset-algolia/note.md'
+
 Returns the highlighted parts of an Algolia hit.
 
 This is a common pattern for Query Suggestions.
 
-## Example with a single string
+<PresetAlgoliaNote />
+
+## Installation
+
+First, you need to install the plugin.
+
+```bash
+yarn add @algolia/autocomplete-preset-algolia@alpha
+# or
+npm install @algolia/autocomplete-preset-algolia@alpha
+```
+
+Then import it in your project:
+
+```js
+import { parseAlgoliaHitReverseHighlight } from '@algolia/autocomplete-preset-algolia';
+```
+
+If you don't use a package manager, you can use a standalone endpoint:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-preset-algolia@alpha"></script>
+```
+
+## Examples
+
+### With a single string
 
 ```js
 import { parseAlgoliaHitReverseHighlight } from '@algolia/autocomplete-preset-algolia';
 
-// Fetch an Algolia hit
+// An Algolia hit for query "lap"
 const hit = {
   name: 'Laptop',
   _highlightResult: {
@@ -25,15 +53,15 @@ const snippetParts = parseAlgoliaHitReverseHighlight({
   attribute: 'name',
 });
 
-// => [{ value: 'Lap', isHighlighted: false }, { value: 'top', isHighlighted: true }]
+// [{ value: 'Lap', isHighlighted: false }, { value: 'top', isHighlighted: true }]
 ```
 
-## Example with nested attributes
+### With nested attributes
 
 ```js
 import { parseAlgoliaHitReverseHighlight } from '@algolia/autocomplete-preset-algolia';
 
-// Fetch an Algolia hit
+// An Algolia hit for query "lap"
 const hit = {
   name: {
     type: 'Laptop',
@@ -51,21 +79,25 @@ const snippetParts = parseAlgoliaHitReverseHighlight({
   attribute: ['name', 'type'],
 });
 
-// => [{ value: 'Lap', isHighlighted: false }, { value: 'top', isHighlighted: true }]
+// [{ value: 'Lap', isHighlighted: false }, { value: 'top', isHighlighted: true }]
 ```
 
-# Reference
-
-## Params
+## Parameters
 
 ### `hit`
 
 > `AlgoliaHit` | required
 
-The Algolia hit to retrieve the attribute value from.
+The Algolia hit whose attribute to retrieve the highlighted parts from.
 
 ### `attribute`
 
 > `string | string[]` | required
 
-The attribute to retrieve the highlight value from. You can use the array syntax to reference the nested attributes.
+The attribute to retrieve the highlighted parts from. You can use the array syntax to reference nested attributes.
+
+## Returns
+
+> `ParsedAttribute[]`
+
+An array of the parsed attribute's parts.

--- a/packages/website/docs/parseAlgoliaHitReverseHighlight.md
+++ b/packages/website/docs/parseAlgoliaHitReverseHighlight.md
@@ -4,7 +4,7 @@ id: parseAlgoliaHitReverseHighlight
 
 import PresetAlgoliaNote from './partials/preset-algolia/note.md'
 
-Returns the highlighted parts of an Algolia hit.
+Returns the highlighted non-matching parts of an Algolia hit.
 
 The `parseAlgoliaHitReverseHighlight` function lets you parse the non-highlighted parts of an Algolia hit. This is a common pattern for [Query Suggestions](https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/query-suggestions/js/), where you want to highlight the differences between each suggestion.
 

--- a/packages/website/docs/parseAlgoliaHitReverseHighlight.md
+++ b/packages/website/docs/parseAlgoliaHitReverseHighlight.md
@@ -48,7 +48,7 @@ const hit = {
     },
   },
 };
-const highlightedParts = parseAlgoliaHitReverseHighlight({
+const reverseHighlightedParts = parseAlgoliaHitReverseHighlight({
   hit,
   attribute: 'name',
 });
@@ -74,7 +74,7 @@ const hit = {
     },
   },
 };
-const highlightedParts = parseAlgoliaHitReverseHighlight({
+const reverseHighlightedParts = parseAlgoliaHitReverseHighlight({
   hit,
   attribute: ['name', 'type'],
 });

--- a/packages/website/docs/parseAlgoliaHitReverseHighlight.md
+++ b/packages/website/docs/parseAlgoliaHitReverseHighlight.md
@@ -6,7 +6,7 @@ import PresetAlgoliaNote from './partials/preset-algolia/note.md'
 
 Returns the highlighted parts of an Algolia hit.
 
-This is a common pattern for Query Suggestions.
+The `parseAlgoliaHitReverseHighlight` function lets you parse the non-highlighted parts of an Algolia hit. This is a common pattern for [Query Suggestions](https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/query-suggestions/js/), where you want to highlight the differences between each suggestion.
 
 <PresetAlgoliaNote />
 

--- a/packages/website/docs/partials/preset-algolia/note.md
+++ b/packages/website/docs/partials/preset-algolia/note.md
@@ -1,0 +1,5 @@
+:::note
+
+If you're using [`autocomplete-js`](/docs/autocomplete-js), all Algolia utilities are available directly in the package with the right user agents and the virtual DOM layer. **You don't need to import the preset separately.**
+
+:::

--- a/packages/website/docs/reverseHighlightHit.md
+++ b/packages/website/docs/reverseHighlightHit.md
@@ -2,36 +2,78 @@
 id: reverseHighlightHit
 ---
 
-Returns a virtual node with non-matching parts of an Algolia hit.
+Returns a virtual node with highlighted non-matching parts of an Algolia hit.
 
-## Example
+## Examples
+
+### With a single string
 
 ```js
-import { reverseHighlightHit } from '@algolia/autocomplete-js';
+import { highlightHit } from '@algolia/autocomplete-js';
 
-const hit = {}; // fetch an Algolia hit
+// An Algolia hit for query "hello"
+const hit = {
+  query: 'Hello there',
+  _highlightResult: {
+    query: {
+      value:
+        'Hello __aa-highlight__there__/aa-highlight__',
+    },
+  },
+};
 const highlightedValue = reverseHighlightHit({
   hit,
   attribute: 'query',
 });
 ```
 
-## Params
+### With nested attributes
+
+```js
+import { highlightHit } from '@algolia/autocomplete-js';
+
+// An Algolia hit for query "hello"
+const hit = {
+  query: {
+    title: 'Hello there',
+  }
+  _highlightResult: {
+    query: {
+      title: {
+        value:
+          'Hello __aa-highlight__there__/aa-highlight__',
+      },
+    },
+  },
+};
+const highlightedValue = highlightHit({
+  hit,
+  attribute: ['query', 'title'],
+});
+```
+
+## Parameters
 
 ### `hit`
 
 > `AlgoliaHit` | required
 
-The Algolia hit to retrieve the attribute value from.
+The Algolia hit whose attribute to retrieve the highlighted parts from.
 
 ### `attribute`
 
-> `string` | required
+> `string | string[]` | required
 
-The attribute to retrieve the highlight value from.
+The attribute to retrieve the highlighted parts from. You can use the array syntax to reference nested attributes.
 
 ### `tagName`
 
 > `string` | defaults to `mark`
 
 The tag name of the virtual node.
+
+## Returns
+
+> `HighlightItemParams<THit>`
+
+A virtual node with the highlighted matching parts.

--- a/packages/website/docs/reverseHighlightHit.md
+++ b/packages/website/docs/reverseHighlightHit.md
@@ -21,7 +21,7 @@ const hit = {
   _highlightResult: {
     query: {
       value:
-        'zelda __aa-highlight__switch__/aa-highlight__',
+        '__aa-highlight__zelda__/aa-highlight__ switch',
     },
   },
 };
@@ -47,7 +47,7 @@ const hit = {
     hierarchicalCategories: {
       lvl1: {
         value:
-          'Video __aa-highlight__games__/aa-highlight__',
+          '__aa-highlight__Video__/aa-highlight__ games',
       },
     },
   },

--- a/packages/website/docs/reverseHighlightHit.md
+++ b/packages/website/docs/reverseHighlightHit.md
@@ -82,4 +82,4 @@ The tag name of the virtual node.
 
 > `HighlightItemParams<THit>`
 
-A virtual node with the highlighted matching parts.
+Virtual nodes with the highlighted matching parts.

--- a/packages/website/docs/reverseHighlightHit.md
+++ b/packages/website/docs/reverseHighlightHit.md
@@ -2,7 +2,7 @@
 id: reverseHighlightHit
 ---
 
-Returns a virtual node with highlighted non-matching parts of an Algolia hit.
+Returns virtual nodes with highlighted non-matching parts of an Algolia hit.
 
  The `reverseHighlightHit` function lets you turn an Algolia hit into a virtual node with highlighted non-matching parts for a given attribute.
 

--- a/packages/website/docs/reverseHighlightHit.md
+++ b/packages/website/docs/reverseHighlightHit.md
@@ -4,9 +4,13 @@ id: reverseHighlightHit
 
 Returns a virtual node with highlighted non-matching parts of an Algolia hit.
 
+ The `reverseHighlightHit` function lets you turn an Algolia hit into a virtual node with highlighted non-matching parts for a given attribute.
+
 ## Examples
 
 ### With a single string
+
+To determine what attribute to parse, you can pass it as a string.
 
 ```js
 import { reverseHighlightHit } from '@algolia/autocomplete-js';
@@ -28,6 +32,8 @@ const reverseHighlightedValue = reverseHighlightHit({
 ```
 
 ### With nested attributes
+
+If you're referencing a nested attribute, you can use the array syntax.
 
 ```js
 import { reverseHighlightHit } from '@algolia/autocomplete-js';

--- a/packages/website/docs/reverseHighlightHit.md
+++ b/packages/website/docs/reverseHighlightHit.md
@@ -9,7 +9,7 @@ Returns a virtual node with highlighted non-matching parts of an Algolia hit.
 ### With a single string
 
 ```js
-import { highlightHit } from '@algolia/autocomplete-js';
+import { reverseHighlightHit } from '@algolia/autocomplete-js';
 
 // An Algolia hit for query "hello"
 const hit = {
@@ -21,7 +21,7 @@ const hit = {
     },
   },
 };
-const highlightedValue = reverseHighlightHit({
+const reverseHighlightedValue = reverseHighlightHit({
   hit,
   attribute: 'query',
 });
@@ -30,7 +30,7 @@ const highlightedValue = reverseHighlightHit({
 ### With nested attributes
 
 ```js
-import { highlightHit } from '@algolia/autocomplete-js';
+import { reverseHighlightHit } from '@algolia/autocomplete-js';
 
 // An Algolia hit for query "hello"
 const hit = {
@@ -46,7 +46,7 @@ const hit = {
     },
   },
 };
-const highlightedValue = highlightHit({
+const reverseHighlightedValue = reverseHighlightHit({
   hit,
   attribute: ['query', 'title'],
 });

--- a/packages/website/docs/reverseHighlightHit.md
+++ b/packages/website/docs/reverseHighlightHit.md
@@ -15,13 +15,13 @@ To determine what attribute to parse, you can pass it as a string.
 ```js
 import { reverseHighlightHit } from '@algolia/autocomplete-js';
 
-// An Algolia hit for query "hello"
+// An Algolia hit for query "zelda"
 const hit = {
-  query: 'Hello there',
+  query: 'zelda switch',
   _highlightResult: {
     query: {
       value:
-        'Hello __aa-highlight__there__/aa-highlight__',
+        'zelda __aa-highlight__switch__/aa-highlight__',
     },
   },
 };
@@ -38,23 +38,23 @@ If you're referencing a nested attribute, you can use the array syntax.
 ```js
 import { reverseHighlightHit } from '@algolia/autocomplete-js';
 
-// An Algolia hit for query "hello"
+// An Algolia hit for query "video"
 const hit = {
-  query: {
-    title: 'Hello there',
+  hierarchicalCategories: {
+    lvl1: 'Video games',
   }
   _highlightResult: {
-    query: {
-      title: {
+    hierarchicalCategories: {
+      lvl1: {
         value:
-          'Hello __aa-highlight__there__/aa-highlight__',
+          'Video __aa-highlight__games__/aa-highlight__',
       },
     },
   },
 };
 const reverseHighlightedValue = reverseHighlightHit({
   hit,
-  attribute: ['query', 'title'],
+  attribute: ['hierarchicalCategories', 'lvl1'],
 });
 ```
 


### PR DESCRIPTION
This rewrites the `parseAlgoliaHitReverseHighlight` docs for `autocomplete-preset-algolia` and `reverseHighlightHit` for `algolia-js`.