### PR TITLE
docs(parseAlgoliaHitSnippet): rewrite guides

### DIFF
--- a/packages/website/docs/parseAlgoliaHitSnippet.md
+++ b/packages/website/docs/parseAlgoliaHitSnippet.md
@@ -12,7 +12,7 @@ The `parseAlgoliaHitSnippet` function lets you parse the highlighted parts of an
 
 ## Installation
 
-First, you need to install the plugin.
+First, you need to install the preset.
 
 ```bash
 yarn add @algolia/autocomplete-preset-algolia@alpha

--- a/packages/website/docs/parseAlgoliaHitSnippet.md
+++ b/packages/website/docs/parseAlgoliaHitSnippet.md
@@ -6,6 +6,8 @@ import PresetAlgoliaNote from './partials/preset-algolia/note.md'
 
 Returns the highlighted parts of an Algolia hit's snippet.
 
+The `parseAlgoliaHitSnippet` function lets you parse the highlighted parts of an Algolia hit's snippet.
+
 <PresetAlgoliaNote />
 
 ## Installation

--- a/packages/website/docs/parseAlgoliaHitSnippet.md
+++ b/packages/website/docs/parseAlgoliaHitSnippet.md
@@ -2,14 +2,42 @@
 id: parseAlgoliaHitSnippet
 ---
 
-Returns the snippeted parts of an Algolia hit.
+import PresetAlgoliaNote from './partials/preset-algolia/note.md'
 
-## Example with a single string
+Returns the highlighted parts of an Algolia hit's snippet.
+
+<PresetAlgoliaNote />
+
+## Installation
+
+First, you need to install the plugin.
+
+```bash
+yarn add @algolia/autocomplete-preset-algolia@alpha
+# or
+npm install @algolia/autocomplete-preset-algolia@alpha
+```
+
+Then import it in your project:
+
+```js
+import { parseAlgoliaHitSnippet } from '@algolia/autocomplete-preset-algolia';
+```
+
+If you don't use a package manager, you can use a standalone endpoint:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-preset-algolia@alpha"></script>
+```
+
+## Examples
+
+### With a single string
 
 ```js
 import { parseAlgoliaHitSnippet } from '@algolia/autocomplete-preset-algolia';
 
-// Fetch an Algolia hit
+// An Algolia hit for query "lap"
 const hit = {
   name: 'Laptop',
   _snippetResult: {
@@ -23,15 +51,15 @@ const snippetParts = parseAlgoliaHitSnippet({
   attribute: 'name',
 });
 
-// => [{ value: 'Lap', isHighlighted: true }, { value: 'top', isHighlighted: false }]
+// [{ value: 'Lap', isHighlighted: true }, { value: 'top', isHighlighted: false }]
 ```
 
-## Example with nested attributes
+### With nested attributes
 
 ```js
 import { parseAlgoliaHitSnippet } from '@algolia/autocomplete-preset-algolia';
 
-// Fetch an Algolia hit
+// An Algolia hit for query "lap"
 const hit = {
   name: {
     type: 'Laptop',
@@ -49,19 +77,25 @@ const snippetParts = parseAlgoliaHitSnippet({
   attribute: ['name', 'type'],
 });
 
-// => [{ value: 'Lap', isHighlighted: true }, { value: 'top', isHighlighted: false }]
+// [{ value: 'Lap', isHighlighted: true }, { value: 'top', isHighlighted: false }]
 ```
 
-## Params
+## Parameters
 
 ### `hit`
 
 > `AlgoliaHit` | required
 
-The Algolia hit to retrieve the attribute value from.
+The Algolia hit whose attribute to retrieve the snippet from.
 
 ### `attribute`
 
 > `string | string[]` | required
 
-The attribute to retrieve the snippet value from. You can use the array syntax to reference the nested attributes.
+The attribute to retrieve the snippet from. You can use the array syntax to reference nested attributes.
+
+## Returns
+
+> `ParsedAttribute[]`
+
+An array of the parsed attribute's parts.

--- a/packages/website/docs/parseAlgoliaHitSnippet.md
+++ b/packages/website/docs/parseAlgoliaHitSnippet.md
@@ -46,7 +46,7 @@ const hit = {
     },
   },
 };
-const snippetParts = parseAlgoliaHitSnippet({
+const snippetedParts = parseAlgoliaHitSnippet({
   hit,
   attribute: 'name',
 });
@@ -72,7 +72,7 @@ const hit = {
     },
   },
 };
-const snippetParts = parseAlgoliaHitSnippet({
+const snippetedParts = parseAlgoliaHitSnippet({
   hit,
   attribute: ['name', 'type'],
 });

--- a/packages/website/docs/partials/preset-algolia/note.md
+++ b/packages/website/docs/partials/preset-algolia/note.md
@@ -1,0 +1,5 @@
+:::note
+
+If you're using [`autocomplete-js`](/docs/autocomplete-js), all Algolia utilities are available directly in the package with the right user agents and the virtual DOM layer. **You don't need to import the preset separately.**
+
+:::

--- a/packages/website/docs/snippetHit.md
+++ b/packages/website/docs/snippetHit.md
@@ -4,9 +4,13 @@ id: snippetHit
 
 Returns a virtual node with highlighted matching parts of an Algolia hit's snippet.
 
+The `snippetHit` function lets you turn an Algolia hit's snippet into a virtual node with highlighted matching parts for a given attribute.
+
 ## Examples
 
 ### With a single string
+
+To determine what attribute to parse, you can pass it as a string.
 
 ```js
 import { snippetHit } from '@algolia/autocomplete-js';
@@ -28,6 +32,8 @@ const snippetedValue = snippetHit({
 ```
 
 ### With nested attributes
+
+If you're referencing a nested attribute, you can use the array syntax.
 
 ```js
 import { snippetHit } from '@algolia/autocomplete-js';

--- a/packages/website/docs/snippetHit.md
+++ b/packages/website/docs/snippetHit.md
@@ -2,42 +2,78 @@
 id: snippetHit
 ---
 
-Returns a virtual node with matching parts of an Algolia hit snippet.
+Returns a virtual node with highlighted matching parts of an Algolia hit's snippet.
 
-## Example
+## Examples
+
+### With a single string
 
 ```js
 import { snippetHit } from '@algolia/autocomplete-js';
 
-const hit = {}; // fetch an Algolia hit
-const snippetedValue = snippetHit({
+// An Algolia hit for query "he"
+const hit = {
+  query: 'Hello there',
+  _snippetResult: {
+    query: {
+      value:
+        '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+    },
+  },
+};
+const snippetValue = snippetHit({
   hit,
   attribute: 'query',
 });
 ```
 
-## Params
+### With nested attributes
+
+```js
+import { snippetHit } from '@algolia/autocomplete-js';
+
+// An Algolia hit for query "he"
+const hit = {
+  query: {
+    title: 'Hello there',
+  }
+  _snippetResult: {
+    query: {
+      title: {
+        value:
+          '__aa-highlight__He__/aa-highlight__llo t__aa-highlight__he__/aa-highlight__re',
+      },
+    },
+  },
+};
+const snippetValue = snippetHit({
+  hit,
+  attribute: ['query', 'title'],
+});
+```
+
+## Parameters
 
 ### `hit`
 
 > `AlgoliaHit` | required
 
-The Algolia hit to retrieve the attribute value from.
+The Algolia hit whose attribute to retrieve the snippet from.
 
 ### `attribute`
 
-> `string` | required
+> `string | string[]` | required
 
-The attribute to retrieve the snippet value from.
-
-### `highlightPreTag`
-
-> `string` | defaults to `<mark>`
-
-The HTML tag to prefix the value with.
+The attribute to retrieve the snippet from. You can use the array syntax to reference nested attributes.
 
 ### `tagName`
 
 > `string` | defaults to `mark`
 
 The tag name of the virtual node.
+
+## Returns
+
+> `HighlightItemParams<THit>`
+
+A virtual node with the snippet.

--- a/packages/website/docs/snippetHit.md
+++ b/packages/website/docs/snippetHit.md
@@ -21,7 +21,7 @@ const hit = {
     },
   },
 };
-const snippetValue = snippetHit({
+const snippetedValue = snippetHit({
   hit,
   attribute: 'query',
 });
@@ -46,7 +46,7 @@ const hit = {
     },
   },
 };
-const snippetValue = snippetHit({
+const snippetedValue = snippetHit({
   hit,
   attribute: ['query', 'title'],
 });

--- a/packages/website/docs/snippetHit.md
+++ b/packages/website/docs/snippetHit.md
@@ -2,7 +2,7 @@
 id: snippetHit
 ---
 
-Returns a virtual node with highlighted matching parts of an Algolia hit's snippet.
+Returns virtual nodes with highlighted matching parts of an Algolia hit's snippet.
 
 The `snippetHit` function lets you turn an Algolia hit's snippet into a virtual node with highlighted matching parts for a given attribute.
 
@@ -82,4 +82,4 @@ The tag name of the virtual node.
 
 > `HighlightItemParams<THit>`
 
-A virtual node with the snippet.
+Virtual nodes with the snippet.


### PR DESCRIPTION
This rewrites the `parseAlgoliaHitSnippet` docs for `autocomplete-preset-algolia` and `snippetHit` for `algolia-js`.