### PR TITLE
doc(sandbox): patch Query Suggestions with Rich Hits

### DIFF
--- a/examples/query-suggestions-with-rich-hits/app.tsx
+++ b/examples/query-suggestions-with-rich-hits/app.tsx
@@ -17,9 +17,13 @@ import insightsClient from 'search-insights';
 import '@algolia/autocomplete-theme-classic';
 
 type Product = {
-  name: string;
-  image: string;
+  brand: string;
+  categories: string[];
   description: string;
+  image: string;
+  name: string;
+  price: number;
+  rating: number;
   __autocomplete_indexName: string;
   __autocomplete_queryID: string;
 };
@@ -65,12 +69,7 @@ autocomplete({
                 query,
                 params: {
                   clickAnalytics: true,
-                  attributesToSnippet: [
-                    'name:10',
-                    'price',
-                    'brand',
-                    'categories[0]',
-                  ],
+                  attributesToSnippet: ['name:10'],
                   snippetEllipsisText: '…',
                 },
               },
@@ -110,15 +109,6 @@ type ProductItemProps = {
   insights: AutocompleteInsightsApi;
 };
 
-const getArray = (nb) => {
-  const tmp = [];
-  for (let i = 0; i < nb; i++) {
-    tmp.push(i);
-  }
-
-  return tmp;
-};
-
 function ProductItem({ hit, insights }: ProductItemProps) {
   return (
     <Fragment>
@@ -128,28 +118,38 @@ function ProductItem({ hit, insights }: ProductItemProps) {
       <div className="aa-ItemContent">
         <div className="aa-ItemContentTitle">
           {snippetHit<ProductHit>({ hit, attribute: 'name' })}
-          <br></br>
-          {snippetHit<ProductHit>({ hit, attribute: 'brand' })}
-          {snippetHit<ProductHit>({ hit, attribute: 'categories[0]' })}
         </div>
         <div className="aa-ItemContentDescription">
-          € {snippetHit<ProductHit>({ hit, attribute: 'price' })}{' '}
-          {getArray(parseInt(hit.rating, 10)).map((i) => {
-            return (
-              <svg
-                key={i}
-                height="12px"
-                viewBox="0 -10 511.98685 511"
-                width="12px"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="m510.652344 185.902344c-3.351563-10.367188-12.546875-17.730469-23.425782-18.710938l-147.773437-13.417968-58.433594-136.769532c-4.308593-10.023437-14.121093-16.511718-25.023437-16.511718s-20.714844 6.488281-25.023438 16.535156l-58.433594 136.746094-147.796874 13.417968c-10.859376 1.003906-20.03125 8.34375-23.402344 18.710938-3.371094 10.367187-.257813 21.738281 7.957031 28.90625l111.699219 97.960937-32.9375 145.089844c-2.410156 10.667969 1.730468 21.695313 10.582031 28.09375 4.757813 3.4375 10.324219 5.1875 15.9375 5.1875 4.839844 0 9.640625-1.304687 13.949219-3.882813l127.46875-76.183593 127.421875 76.183593c9.324219 5.609376 21.078125 5.097657 29.910156-1.304687 8.855469-6.417969 12.992187-17.449219 10.582031-28.09375l-32.9375-145.089844 111.699219-97.941406c8.214844-7.1875 11.351563-18.539063 7.980469-28.925781zm0 0"
-                  fill="#ffc107"
-                />
-              </svg>
-            );
-          })}
+          From <strong>{hit.brand}</strong> in{' '}
+          <strong>{hit.categories[0]}</strong>
+        </div>
+        {hit.rating > 0 && (
+          <div className="aa-ItemContentDescription">
+            <div style={{ display: 'flex', gap: 1, color: '#ffc107' }}>
+              {Array.from({ length: 5 }, (_value, index) => {
+                const isFilled = hit.rating >= index + 1;
+
+                return (
+                  <svg
+                    key={index}
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill={isFilled ? 'currentColor' : 'none'}
+                    stroke="currentColor"
+                    strokeWidth="3"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+                  </svg>
+                );
+              })}
+            </div>
+          </div>
+        )}
+        <div className="aa-ItemContentDescription" style={{ color: '#000' }}>
+          <strong>${hit.price.toLocaleString()}</strong>
         </div>
       </div>
       <div className="aa-ItemActions">


### PR DESCRIPTION
## Description

This is a proposal to improve the "Query Suggestions with Rich Hits" example (#486).

Some styles were inlined because they will be covered from the Classic Theme soon.

## Preview

![image](https://user-images.githubusercontent.com/6137112/109946248-507bc180-7cd8-11eb-9f82-b63bf6779053.png)
