### PR TITLE
feat(js): pass `elements` record to `render`

### DIFF
--- a/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
+++ b/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
@@ -319,6 +319,7 @@ describe('autocomplete-js', () => {
         state: expect.anything(),
         children: expect.anything(),
         sections: expect.any(Array),
+        elements: expect.any(Object),
         createElement: expect.anything(),
         Fragment: expect.anything(),
       },

--- a/packages/autocomplete-js/src/render.tsx
+++ b/packages/autocomplete-js/src/render.tsx
@@ -168,6 +168,13 @@ export function renderPanel<TItem extends BaseItem>(
   const children = (
     <div className="aa-PanelLayout aa-Panel--Scrollable">{sections}</div>
   );
+  const elements = sections.reduce((acc, current) => {
+    acc[current.props['data-autocomplete-source-id']] = current;
+    return acc;
+  }, {});
 
-  render({ children, state, sections, createElement, Fragment }, dom.panel);
+  render(
+    { children, state, sections, elements, createElement, Fragment },
+    dom.panel
+  );
 }

--- a/packages/autocomplete-js/src/types/AutocompleteRender.ts
+++ b/packages/autocomplete-js/src/types/AutocompleteRender.ts
@@ -8,6 +8,7 @@ export type AutocompleteRender<TItem extends BaseItem> = (
     children: VNode;
     state: AutocompleteState<TItem>;
     sections: VNode[];
+    elements: Record<string, VNode>;
     createElement: Pragma;
     Fragment: PragmaFrag;
   },


### PR DESCRIPTION
This adds an API to easily retrieve generated UI elements to manipulate the panel UI.

## Why

Finding the right source to render in the panel was cumbersome, and sometimes created friction to generate advanced conditional layouts.

## How

We use the `sourceId` (which is required) as the key to the `elements` record:

```ts
const querySuggestionsPlugin = elements.querySuggestionsPlugin; // or
const querySuggestionsPlugin = elements['querySuggestionsPlugin']; // or
const { querySuggestionsPlugin } = elements;
```

This makes flows easier to render because with flows, some key values can be `undefined` (because `getSources` doesn't return them). In JSX, rendering `undefined` renders nothing, which is convenient.

## API

### Before

```ts
import { render } from 'preact';

autocomplete({
  // ...
  plugins: [recentSearchesPlugin, querySuggestionsPlugin],
  getSources({ query }) {
    return [
      {
        sourceId: 'products',
        // ...
      },
    ];
  },
  render({ sections }, root) {
    const recentSearches = sections.find(
      (x) => x.props["data-autocomplete-source-id"] === "recentSearchesPlugin"
    );
    const querySuggestions = sections.find(
      (x) => x.props["data-autocomplete-source-id"] === "querySuggestionsPlugin"
    );
    const products = sections.find(
      (x) => x.props["data-autocomplete-source-id"] === "products"
    );

    render(
      <div className="aa-PanelLayout">
        <div>
          {recentSearches}
          {querySuggestions}
        </div>
        <div>{products}</div>
      </div>,
      root
    );
  },
});
```

### After

#### Single flow

```ts
import { render } from 'preact';

autocomplete({
  // ...
  plugins: [recentSearchesPlugin, querySuggestionsPlugin],
  getSources({ query }) {
    return [
      {
        sourceId: 'products',
        // ...
      },
    ];
  },
  render({ elements }, root) {
    const { recentSearchesPlugin, querySuggestionsPlugin, products } = elements;

    render(
      <div className="aa-PanelLayout">
        <div>
          {recentSearchesPlugin}
          {querySuggestionsPlugin}
        </div>
        <div>{products}</div>
      </div>,
      root
    );
  },
});
```

#### Multiple flows

```ts
import { render } from 'preact';

autocomplete({
  // ...
  plugins: [recentSearchesPlugin, querySuggestionsPlugin],
  getSources({ query, state }) {
    if (state.context.flow === 'editing') {
      return [
        {
          sourceId: 'draftProducts',
          // ...
        },
      ];
    }

    return [
      {
        sourceId: 'products',
        // ...
      },
    ];
  },
  render({ elements, state }, root) {
    const {
      recentSearchesPlugin,
      querySuggestionsPlugin,
      products,
      draftProducts,
    } = elements;

    switch (state.context.flow) {
      case 'editing':
        render(
          <div className="aa-PanelLayout">
            <Editor draftProducts={draftProducts} />
          </div>,
          root
        );
        break;

      default:
        render(
          <div className="aa-PanelLayout">
            <div>
              {recentSearchesPlugin}
              {querySuggestionsPlugin}
            </div>
            <div>{products}</div>
          </div>,
          root
        );
    }
  },
});
```