### PR TITLE
fix(qs): rename `categoriesLimit` to `itemsWithCategories`

### DIFF
--- a/examples/query-suggestions-with-inline-categories/app.tsx
+++ b/examples/query-suggestions-with-inline-categories/app.tsx
@@ -24,8 +24,7 @@ const querySuggestionsPlugin = createQuerySuggestionsPlugin({
     'exact_matches',
     'categories',
   ],
-  categoriesPerItem: 1,
-  categoriesLimit: 2,
+  categoriesPerItem: 2,
   transformSource: ({ source, onTapAhead }) => {
     return {
       ...source,

--- a/packages/autocomplete-plugin-query-suggestions/src/createQuerySuggestionsPlugin.ts
+++ b/packages/autocomplete-plugin-query-suggestions/src/createQuerySuggestionsPlugin.ts
@@ -30,7 +30,7 @@ export type CreateQuerySuggestionsPluginParams<
    * The number of items to display categories for.
    * @default 1
    */
-  categoriesLimit?: number;
+  itemsWithCategories?: number;
   /**
    * The number of categories to display per item.
    * @default 1
@@ -46,8 +46,8 @@ export function createQuerySuggestionsPlugin<
   getSearchParams = () => ({}),
   transformSource = ({ source }) => source,
   categoryAttribute,
+  itemsWithCategories = 1,
   categoriesPerItem = 1,
-  categoriesLimit = 1,
 }: CreateQuerySuggestionsPluginParams<TItem>): AutocompletePlugin<
   TItem,
   undefined
@@ -88,7 +88,7 @@ export function createQuerySuggestionsPlugin<
                     AutocompleteQuerySuggestionsHit<typeof indexName>
                   > = [current];
 
-                  if (i <= categoriesPerItem - 1) {
+                  if (i <= itemsWithCategories - 1) {
                     const categories = getAttributeValueByPath(
                       current,
                       Array.isArray(categoryAttribute)
@@ -96,7 +96,7 @@ export function createQuerySuggestionsPlugin<
                         : [categoryAttribute]
                     )
                       .map((x) => x.value)
-                      .slice(0, categoriesLimit);
+                      .slice(0, categoriesPerItem);
 
                     for (const category of categories) {
                       items.push({

--- a/packages/website/docs/adding-suggested-searches.mdx
+++ b/packages/website/docs/adding-suggested-searches.mdx
@@ -23,7 +23,7 @@ const querySuggestionsPluginWithCategories = createQuerySuggestionsPlugin({
     'exact_matches',
     'categories',
   ],
-  categoriesLimit: 2,
+  itemsWithCategories: 2,
   categoriesPerItem: 2,
 });
 
@@ -148,7 +148,7 @@ To display categories with the suggestions, you need to define the attribute to 
 
 In this example, the category data is stored in the nested attribute `instant_search.facets.exact_matches.categories`. With this structure, you need to provide the path `["instant_search", "facets", "exact_matches", "categories"]` as the `categoryAttribute`.
 
-You can also set the number of items to display categories for using `categoriesLimit` and the maximum number of categories to display per item using `categoriesPerItem`. Both default to `1`.
+You can also set the number of items to display categories for using `itemsWithCategories` and the maximum number of categories to display per item using `categoriesPerItem`. Both default to `1`.
 
 ```js title="index.js"
 import { autocomplete } from '@algolia/autocomplete-js';
@@ -170,7 +170,7 @@ const querySuggestionsPlugin = createQuerySuggestionsPlugin({
     'exact_matches',
     'categories',
   ],
-  categoriesLimit: 2,
+  itemsWithCategories: 2,
   categoriesPerItem: 2,
 });
 

--- a/packages/website/docs/createQuerySuggestionsPlugin.md
+++ b/packages/website/docs/createQuerySuggestionsPlugin.md
@@ -179,7 +179,7 @@ const querySuggestionsPlugin = createQuerySuggestionsPlugin({
 });
 ```
 
-### `categoriesLimit`
+### `itemsWithCategories`
 
 > `number` | defaults to `1`
 

--- a/packages/website/docs/introduction.mdx
+++ b/packages/website/docs/introduction.mdx
@@ -25,7 +25,7 @@ const querySuggestionsPlugin = createQuerySuggestionsPlugin({
     'exact_matches',
     'categories',
   ],
-  categoriesLimit: 2,
+  categoriesPerItem: 2,
 });
 const productsPlugin = createProductsPlugin();
 const productsPluginWithHeader = createProductsPlugin({


### PR DESCRIPTION
## Description

This renames the Query Suggestions plugin option `categoriesLimit` to `itemsWithCategories`.

(The previous options were also inverted in the QS plugin, so this rename fixes it.)

## Related

- https://github.com/algolia/autocomplete/pull/468#discussion_r584529644