### PR TITLE
fix(js): remove `window` references

### DIFF
--- a/packages/autocomplete-js/src/autocomplete.ts
+++ b/packages/autocomplete-js/src/autocomplete.ts
@@ -281,7 +281,7 @@ export function autocomplete<TItem extends BaseItem>(
       toggleModalClassname(event.matches);
     }
 
-    const isModalDetachedMql = window.matchMedia(
+    const isModalDetachedMql = props.value.core.environment.matchMedia(
       getComputedStyle(
         props.value.core.environment.document.documentElement
       ).getPropertyValue('--aa-detached-modal-media-query')

--- a/packages/autocomplete-js/src/getPanelPlacementStyle.ts
+++ b/packages/autocomplete-js/src/getPanelPlacementStyle.ts
@@ -1,7 +1,7 @@
 import { AutocompleteOptions } from './types';
 
 type GetPanelPlacementStyleParams = Pick<
-  AutocompleteOptions<any>,
+  Required<AutocompleteOptions<any>>,
   'panelPlacement' | 'environment'
 > & {
   container: HTMLElement;
@@ -12,7 +12,7 @@ export function getPanelPlacementStyle({
   panelPlacement,
   container,
   form,
-  environment = window,
+  environment,
 }: GetPanelPlacementStyleParams) {
   const containerRect = container.getBoundingClientRect();
   const top = container.offsetTop + containerRect.height;


### PR DESCRIPTION
This removes all `window` references in Autocomplete JS to support SSR.