### PR TITLE
feat(autocomplete-theme-classic): align search box properly

### DIFF
--- a/examples/github-repositories-custom-plugin/createGitHubReposPlugin.tsx
+++ b/examples/github-repositories-custom-plugin/createGitHubReposPlugin.tsx
@@ -70,55 +70,57 @@ export function createGitHubReposPlugin(
 
                   return (
                     <Fragment>
-                      <div className="aa-ItemIcon">
-                        <img
-                          src={item.owner.avatar_url}
-                          alt={item.full_name}
-                          width="40"
-                          height="40"
-                        />
-                      </div>
                       <div className="aa-ItemContent">
-                        <div className="aa-ItemContentTitle">
-                          <div style={{ display: 'flex' }}>
-                            <div>{item.full_name}</div>
-                            <div
-                              style={{
-                                alignItems: 'center',
-                                display: 'flex',
-                                marginLeft: 'var(--aa-spacing-half)',
-                                position: 'relative',
-                                top: '1px',
-                              }}
-                            >
-                              <svg
-                                aria-label={`${stars} stars`}
+                        <div className="aa-ItemIcon aa-ItemIcon--alignTop">
+                          <img
+                            src={item.owner.avatar_url}
+                            alt={item.full_name}
+                            width="40"
+                            height="40"
+                          />
+                        </div>
+                        <div className="aa-ItemContentBody">
+                          <div className="aa-ItemContentTitle">
+                            <div style={{ display: 'flex' }}>
+                              <div>{item.full_name}</div>
+                              <div
                                 style={{
-                                  display: 'block',
-                                  width: 'calc(var(--aa-spacing-half) * 2)',
-                                  height: 'calc(var(--aa-spacing-half) * 2)',
-                                  color: '#ffa724',
-                                }}
-                                viewBox="0 0 20 20"
-                                fill="currentColor"
-                              >
-                                <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-                              </svg>{' '}
-                              <span
-                                aria-hidden="true"
-                                style={{
-                                  color: 'var(--aa-content-text-color)',
-                                  fontSize: '0.8em',
-                                  lineHeight: 'normal',
+                                  alignItems: 'center',
+                                  display: 'flex',
+                                  marginLeft: 'var(--aa-spacing-half)',
+                                  position: 'relative',
+                                  top: '1px',
                                 }}
                               >
-                                {stars}
-                              </span>
+                                <svg
+                                  aria-label={`${stars} stars`}
+                                  style={{
+                                    display: 'block',
+                                    width: 'calc(var(--aa-spacing-half) * 2)',
+                                    height: 'calc(var(--aa-spacing-half) * 2)',
+                                    color: '#ffa724',
+                                  }}
+                                  viewBox="0 0 20 20"
+                                  fill="currentColor"
+                                >
+                                  <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                                </svg>{' '}
+                                <span
+                                  aria-hidden="true"
+                                  style={{
+                                    color: 'var(--aa-content-text-color)',
+                                    fontSize: '0.8em',
+                                    lineHeight: 'normal',
+                                  }}
+                                >
+                                  {stars}
+                                </span>
+                              </div>
                             </div>
                           </div>
-                        </div>
-                        <div className="aa-ItemContentDescription">
-                          {item.description}
+                          <div className="aa-ItemContentDescription">
+                            {item.description}
+                          </div>
                         </div>
                       </div>
                       <div className="aa-ItemActions">

--- a/packages/autocomplete-theme-classic/src/theme.scss
+++ b/packages/autocomplete-theme-classic/src/theme.scss
@@ -171,7 +171,6 @@ body {
     display: flex;
     line-height: 1em;
     margin: 0;
-    padding: 0 calc(var(--aa-spacing) - 2px) 0 calc(var(--aa-spacing) - 1px);
     position: relative;
     width: 100%;
     &:focus-within {
@@ -189,28 +188,47 @@ body {
       align-items: center;
       display: flex;
       flex-shrink: 0;
+      height: var(--aa-search-input-height);
       order: 1;
       // Container for search and loading icons
       @at-root .aa-Label,
         .aa-LoadingIndicator {
         cursor: initial;
         flex-shrink: 0;
+        height: 100%;
         padding: 0;
         text-align: left;
-        width: calc(var(--aa-icon-size) + var(--aa-spacing));
-        button {
-          appearance: none;
-          background: none;
-          border: 0;
-          margin: 0;
-          padding: 2px;
-        }
         svg {
           color: rgba(var(--aa-primary-color-rgb), 1);
           height: auto;
           max-height: var(--aa-input-icon-size);
           stroke-width: var(--aa-icon-stroke-width);
           width: var(--aa-input-icon-size);
+        }
+      }
+      @at-root .aa-SubmitButton,
+        .aa-LoadingIndicator {
+        height: 100%;
+        padding-left: calc(var(--aa-spacing) * 0.75 - 1px);
+        padding-right: var(--aa-spacing-half);
+        width: calc(var(--aa-spacing) * 1.75 + var(--aa-icon-size) - 1px);
+        @media (hover: none) and (pointer: coarse) {
+          padding-left: calc(var(--aa-spacing-half) / 2 - 1px);
+          width: calc(var(--aa-icon-size) + (var(--aa-spacing) * 1.25) - 1px);
+        }
+      }
+      @at-root .aa-SubmitButton {
+        appearance: none;
+        background: none;
+        border: 0;
+        margin: 0;
+      }
+      @at-root .aa-LoadingIndicator {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        &[hidden] {
+          display: none;
         }
       }
     }
@@ -226,6 +244,7 @@ body {
         color: rgba(var(--aa-text-color-rgb), var(--aa-text-color-alpha));
         font: inherit;
         height: var(--aa-search-input-height);
+        padding: 0;
         width: 100%;
         &::placeholder {
           color: rgba(var(--aa-muted-color-rgb), var(--aa-muted-color-alpha));
@@ -250,6 +269,7 @@ body {
       align-items: center;
       display: flex;
       order: 4;
+      height: var(--aa-search-input-height);
       // Accelerator to clear the query
       @at-root .aa-ClearButton {
         align-items: center;
@@ -259,7 +279,11 @@ body {
         cursor: pointer;
         display: flex;
         margin: 0;
-        padding: 2px;
+        height: 100%;
+        padding: 0 calc(var(--aa-spacing) * (5 / 6) - 0.5px);
+        @media (hover: none) and (pointer: coarse) {
+          padding: 0 calc(var(--aa-spacing) * (2 / 3) - 0.5px);
+        }
         &:hover,
         &:focus {
           color: rgba(var(--aa-text-color-rgb), var(--aa-text-color-alpha));

--- a/packages/autocomplete-theme-classic/src/theme.scss
+++ b/packages/autocomplete-theme-classic/src/theme.scss
@@ -224,8 +224,8 @@ body {
         margin: 0;
       }
       @at-root .aa-LoadingIndicator {
-        display: flex;
         align-items: center;
+        display: flex;
         justify-content: center;
         &[hidden] {
           display: none;
@@ -268,8 +268,8 @@ body {
     @at-root .aa-InputWrapperSuffix {
       align-items: center;
       display: flex;
-      order: 4;
       height: var(--aa-search-input-height);
+      order: 4;
       // Accelerator to clear the query
       @at-root .aa-ClearButton {
         align-items: center;
@@ -278,8 +278,8 @@ body {
         color: rgba(var(--aa-muted-color-rgb), var(--aa-muted-color-alpha));
         cursor: pointer;
         display: flex;
-        margin: 0;
         height: 100%;
+        margin: 0;
         padding: 0 calc(var(--aa-spacing) * (5 / 6) - 0.5px);
         @media (hover: none) and (pointer: coarse) {
           padding: 0 calc(var(--aa-spacing) * (2 / 3) - 0.5px);


### PR DESCRIPTION
This tweaks the styles so that the search box visually aligns on other elements. This applies to the loading indicator too, and optimizes for the largest possible clickable/tappable area on the submit and clear buttons.

<details><summary><strong>Desktop</strong></summary>

![Capture d’écran 2021-04-01 à 19 41 08 (2)](https://user-images.githubusercontent.com/5370675/113339286-8db08f00-932a-11eb-896a-9812b2ed3c0e.png)

![Capture d’écran 2021-04-01 à 19 41 20 (2)](https://user-images.githubusercontent.com/5370675/113339300-91441600-932a-11eb-8ad5-c54b1e661d65.png)

![Capture d’écran 2021-04-01 à 19 41 24 (2)](https://user-images.githubusercontent.com/5370675/113339324-986b2400-932a-11eb-8a8d-165e26e857da.png)

</details>

<details><summary><strong>Mobile</strong></summary>

![Capture d’écran 2021-04-01 à 20 36 50](https://user-images.githubusercontent.com/5370675/113339341-9dc86e80-932a-11eb-88a2-32e80fde4870.png)

![Capture d’écran 2021-04-01 à 20 37 00 (2)](https://user-images.githubusercontent.com/5370675/113339354-a15bf580-932a-11eb-8cf3-80e2c698b2a3.png)

![Capture d’écran 2021-04-01 à 20 37 07 (2)](https://user-images.githubusercontent.com/5370675/113339370-a4ef7c80-932a-11eb-8e47-1ad5c6e78e0c.png)

</details>

On mobile, the submit icon has to be close to the left edge to align with the icons below. I didn't replicate this exact gap between the clear button and the right edge, because it looked weird. I've tried to find a gap that felt right instead. It looks a bit odd when looking at it on a computer screen, but feels smooth on a mobile device.

I've tried to simplify the `calc` statements as much as possible so they don't wrap and are easier to read. Whenever a factor or divisor doesn't equal to a fixed decimal value, I used fractions to avoid losing precision.