### PR TITLE
feat(plugins): provide `state` to `transformSource`

### DIFF
--- a/examples/recently-viewed-items/recentlyViewedItemsPlugin.tsx
+++ b/examples/recently-viewed-items/recentlyViewedItemsPlugin.tsx
@@ -48,9 +48,9 @@ export function createLocalStorageRecentlyViewedItems<
 
       return search(params);
     },
-    transformSource({ source, onRemove }) {
+    transformSource({ source, onRemove, state }) {
       const transformedSource = params.transformSource
-        ? params.transformSource({ source, onRemove })
+        ? params.transformSource({ source, onRemove, state })
         : source;
 
       return {

--- a/packages/autocomplete-plugin-query-suggestions/src/createQuerySuggestionsPlugin.ts
+++ b/packages/autocomplete-plugin-query-suggestions/src/createQuerySuggestionsPlugin.ts
@@ -18,6 +18,7 @@ export type CreateQuerySuggestionsPluginParams<
   getSearchParams?(params: { state: AutocompleteState<TItem> }): SearchOptions;
   transformSource?(params: {
     source: AutocompleteSource<TItem>;
+    state: AutocompleteState<TItem>;
     onTapAhead(item: TItem): void;
   }): AutocompleteSource<TItem>;
   /**
@@ -115,6 +116,7 @@ export function createQuerySuggestionsPlugin<
             templates: getTemplates({ onTapAhead }),
           },
           onTapAhead,
+          state,
         }),
       ];
     },

--- a/packages/autocomplete-plugin-recent-searches/src/createRecentSearchesPlugin.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/createRecentSearchesPlugin.ts
@@ -1,5 +1,6 @@
 import {
   AutocompletePlugin,
+  AutocompleteState,
   PluginSubscribeParams,
 } from '@algolia/autocomplete-core';
 import { AutocompleteSource } from '@algolia/autocomplete-js';
@@ -21,6 +22,7 @@ export type CreateRecentSearchesPluginParams<
   storage: Storage<TItem>;
   transformSource?(params: {
     source: AutocompleteSource<TItem>;
+    state: AutocompleteState<TItem>;
     onRemove(id: string): void;
     onTapAhead(item: TItem): void;
   }): AutocompleteSource<TItem>;
@@ -70,7 +72,7 @@ export function createRecentSearchesPlugin<TItem extends RecentSearchesItem>({
         store.addItem(recentItem as TItem);
       }
     },
-    getSources({ query, setQuery, refresh }) {
+    getSources({ query, setQuery, refresh, state }) {
       lastItemsRef.current = store.getAll(query);
 
       function onRemove(id: string) {
@@ -102,6 +104,7 @@ export function createRecentSearchesPlugin<TItem extends RecentSearchesItem>({
             },
             onRemove,
             onTapAhead,
+            state,
           }),
         ];
       });

--- a/packages/website/docs/createLocalStorageRecentSearchesPlugin.md
+++ b/packages/website/docs/createLocalStorageRecentSearchesPlugin.md
@@ -140,7 +140,7 @@ function search({ query, items, limit }) {
 
 ### `transformSource`
 
-> `(params: { source: AutocompleteSource, onRemove: () => void, onTapAhead: () => void })`
+> `(params: { source: AutocompleteSource, state: AutocompleteState, onRemove: () => void, onTapAhead: () => void })`
 
 A function to transform the provided source.
 

--- a/packages/website/docs/createQuerySuggestionsPlugin.md
+++ b/packages/website/docs/createQuerySuggestionsPlugin.md
@@ -104,7 +104,7 @@ A function returning [Algolia search parameters](https://www.algolia.com/doc/api
 
 ### `transformSource`
 
-> `(params: { source: AutocompleteSource, onTapAhead: () => void })`
+> `(params: { source: AutocompleteSource, state: AutocompleteState, onTapAhead: () => void })`
 
 A function to transform the provided source.
 

--- a/packages/website/docs/createRecentSearchesPlugin.md
+++ b/packages/website/docs/createRecentSearchesPlugin.md
@@ -145,7 +145,7 @@ type RecentSearchesStorage<TItem extends RecentSearchesItem> = {
 
 ### `transformSource`
 
-> `(params: { source: AutocompleteSource, onRemove: () => void, onTapAhead: () => void })`
+> `(params: { source: AutocompleteSource, state: AutocompleteState, onRemove: () => void, onTapAhead: () => void })`
 
 A function to transform the provided source.
 


### PR DESCRIPTION
## Description

When transforming plugin sources, you sometimes need to access the state to conditionally apply some logic. Providing the Autocomplete `state` to `transformSource` allow these use cases.

## Usage

Example of Query Suggestions hidden when there's no query.

```ts
const querySuggestionsPlugin = createQuerySuggestionsPlugin({
  searchClient,
  indexName: 'instant_search_demo_query_suggestions',
  transformSource({ source, state }) {
    if (!state.query) {
      return null;
    }

    return source;
  },
});
```