### PR TITLE
docs: document `script` tag imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,13 @@ yarn add @algolia/autocomplete-js@alpha
 npm install @algolia/autocomplete-js@alpha
 ```
 
-If you don't want to use a package manager, you can use a standalone endpoint:
+If you don't use a package manager, you can use the HTML `script` element:
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-js@alpha"></script>
+<script>
+  const { autocomplete } = window['@algolia/autocomplete-js'];
+</script>
 ```
 
 ## Usage

--- a/packages/website/docs/autocomplete-js.md
+++ b/packages/website/docs/autocomplete-js.md
@@ -23,10 +23,13 @@ Then import it in your project:
 import { autocomplete } from '@algolia/autocomplete-js';
 ```
 
-If you don't use a package manager, you can use a standalone endpoint:
+If you don't use a package manager, you can use the HTML `script` element:
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-js@alpha"></script>
+<script>
+  const { autocomplete } = window['@algolia/autocomplete-js'];
+</script>
 ```
 
 ## Example

--- a/packages/website/docs/createAlgoliaInsightsPlugin.md
+++ b/packages/website/docs/createAlgoliaInsightsPlugin.md
@@ -20,10 +20,15 @@ Then import it in your project:
 import { createAlgoliaInsightsPlugin } from '@algolia/autocomplete-plugin-algolia-insights';
 ```
 
-If you don't use a package manager, you can use a standalone endpoint:
+If you don't use a package manager, you can use the HTML `script` element:
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-plugin-algolia-insights@alpha"></script>
+<script>
+  const { createAlgoliaInsightsPlugin } = window[
+    '@algolia/autocomplete-plugin-algolia-insights'
+  ];
+</script>
 ```
 
 ## Examples

--- a/packages/website/docs/createAutocomplete.md
+++ b/packages/website/docs/createAutocomplete.md
@@ -28,10 +28,13 @@ Then import it in your project:
 import { createAutocomplete } from '@algolia/autocomplete-core';
 ```
 
-If you don't use a package manager, you can use a standalone endpoint:
+If you don't use a package manager, you can use the HTML `script` element:
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-core@alpha"></script>
+<script>
+  const { createAutocomplete } = window['@algolia/autocomplete-core'];
+</script>
 ```
 
 ## Example

--- a/packages/website/docs/createLocalStorageRecentSearchesPlugin.md
+++ b/packages/website/docs/createLocalStorageRecentSearchesPlugin.md
@@ -19,7 +19,7 @@ npm install @algolia/autocomplete-plugin-recent-searches@alpha
 Then import it in your project:
 
 ```js
-import { createRecentSearchesPlugin } from '@algolia/autocomplete-plugin-recent-searches';
+import { createLocalStorageRecentSearchesPlugin } from '@algolia/autocomplete-plugin-recent-searches';
 ```
 
 If you don't use a package manager, you can use the HTML `script` element:
@@ -27,7 +27,7 @@ If you don't use a package manager, you can use the HTML `script` element:
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-plugin-recent-searches@alpha"></script>
 <script>
-  const { createRecentSearchesPlugin } = window[
+  const { createLocalStorageRecentSearchesPlugin } = window[
     '@algolia/autocomplete-plugin-recent-searches'
   ];
 </script>

--- a/packages/website/docs/createLocalStorageRecentSearchesPlugin.md
+++ b/packages/website/docs/createLocalStorageRecentSearchesPlugin.md
@@ -22,10 +22,15 @@ Then import it in your project:
 import { createRecentSearchesPlugin } from '@algolia/autocomplete-plugin-recent-searches';
 ```
 
-If you don't use a package manager, you can use a standalone endpoint:
+If you don't use a package manager, you can use the HTML `script` element:
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-plugin-recent-searches@alpha"></script>
+<script>
+  const { createRecentSearchesPlugin } = window[
+    '@algolia/autocomplete-plugin-recent-searches'
+  ];
+</script>
 ```
 
 ## Example

--- a/packages/website/docs/createQuerySuggestionsPlugin.md
+++ b/packages/website/docs/createQuerySuggestionsPlugin.md
@@ -20,10 +20,15 @@ Then import it in your project:
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
 ```
 
-If you don't use a package manager, you can use a standalone endpoint:
+If you don't use a package manager, you can use the HTML `script` element:
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-plugin-query-suggestions@alpha"></script>
+<script>
+  const { createQuerySuggestionsPlugin } = window[
+    '@algolia/autocomplete-plugin-query-suggestions'
+  ];
+</script>
 ```
 
 ## Example

--- a/packages/website/docs/createRecentSearchesPlugin.md
+++ b/packages/website/docs/createRecentSearchesPlugin.md
@@ -22,10 +22,15 @@ Then import it in your project:
 import { createRecentSearchesPlugin } from '@algolia/autocomplete-plugin-recent-searches';
 ```
 
-If you don't use a package manager, you can use a standalone endpoint:
+If you don't use a package manager, you can use the HTML `script` element:
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-plugin-recent-searches@alpha"></script>
+<script>
+  const { createRecentSearchesPlugin } = window[
+    '@algolia/autocomplete-plugin-recent-searches'
+  ];
+</script>
 ```
 
 ## Example

--- a/packages/website/docs/getAlgoliaFacetHits-js.mdx
+++ b/packages/website/docs/getAlgoliaFacetHits-js.mdx
@@ -3,7 +3,7 @@ id: getAlgoliaFacetHits-js
 title: getAlgoliaFacetHits
 ---
 
-import GetAlgoliaFacetHitsIntro from './partials/preset-algolia/getAlgoliaFacetHits/intro.md'
+import GetAlgoliaFacetHitsIntro from './partials/preset-algolia/getAlgoliaFacetHits/intro.md';
 
 <GetAlgoliaFacetHitsIntro />
 

--- a/packages/website/docs/getAlgoliaFacetHits.mdx
+++ b/packages/website/docs/getAlgoliaFacetHits.mdx
@@ -25,10 +25,15 @@ Then import it in your project:
 import { getAlgoliaFacetHits } from '@algolia/autocomplete-preset-algolia';
 ```
 
-If you don't use a package manager, you can use a standalone endpoint:
+If you don't use a package manager, you can use the HTML `script` element:
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-preset-algolia@alpha"></script>
+<script>
+  const { getAlgoliaFacetHits } = window[
+    '@algolia/autocomplete-preset-algolia'
+  ];
+</script>
 ```
 
 ## Example

--- a/packages/website/docs/getAlgoliaHits-js.mdx
+++ b/packages/website/docs/getAlgoliaHits-js.mdx
@@ -3,7 +3,7 @@ id: getAlgoliaHits-js
 title: getAlgoliaHits
 ---
 
-import GetAlgoliaHitsIntro from './partials/preset-algolia/getAlgoliaHits/intro.md'
+import GetAlgoliaHitsIntro from './partials/preset-algolia/getAlgoliaHits/intro.md';
 
 <GetAlgoliaHitsIntro />
 

--- a/packages/website/docs/getAlgoliaHits.mdx
+++ b/packages/website/docs/getAlgoliaHits.mdx
@@ -2,8 +2,8 @@
 id: getAlgoliaHits
 ---
 
-import GetAlgoliaHitsIntro from './partials/preset-algolia/getAlgoliaHits/intro.md'
-import PresetAlgoliaNote from './partials/preset-algolia/note.md'
+import GetAlgoliaHitsIntro from './partials/preset-algolia/getAlgoliaHits/intro.md';
+import PresetAlgoliaNote from './partials/preset-algolia/note.md';
 
 <GetAlgoliaHitsIntro />
 
@@ -25,10 +25,13 @@ Then import it in your project:
 import { getAlgoliaHits } from '@algolia/autocomplete-preset-algolia';
 ```
 
-If you don't use a package manager, you can use a standalone endpoint:
+If you don't use a package manager, you can use the HTML `script` element:
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-preset-algolia@alpha"></script>
+<script>
+  const { getAlgoliaHits } = window['@algolia/autocomplete-preset-algolia'];
+</script>
 ```
 
 ## Example

--- a/packages/website/docs/getAlgoliaResults-js.mdx
+++ b/packages/website/docs/getAlgoliaResults-js.mdx
@@ -3,7 +3,7 @@ id: getAlgoliaResults-js
 title: getAlgoliaResults
 ---
 
-import GetAlgoliaResultsIntro from './partials/preset-algolia/getAlgoliaResults/intro.md'
+import GetAlgoliaResultsIntro from './partials/preset-algolia/getAlgoliaResults/intro.md';
 
 <GetAlgoliaResultsIntro />
 

--- a/packages/website/docs/getAlgoliaResults.mdx
+++ b/packages/website/docs/getAlgoliaResults.mdx
@@ -2,8 +2,8 @@
 id: getAlgoliaResults
 ---
 
-import GetAlgoliaResultsIntro from './partials/preset-algolia/getAlgoliaResults/intro.md'
-import PresetAlgoliaNote from './partials/preset-algolia/note.md'
+import GetAlgoliaResultsIntro from './partials/preset-algolia/getAlgoliaResults/intro.md';
+import PresetAlgoliaNote from './partials/preset-algolia/note.md';
 
 <GetAlgoliaResultsIntro />
 
@@ -25,10 +25,13 @@ Then import it in your project:
 import { getAlgoliaResults } from '@algolia/autocomplete-preset-algolia';
 ```
 
-If you don't use a package manager, you can use a standalone endpoint:
+If you don't use a package manager, you can use the HTML `script` element:
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-preset-algolia@alpha"></script>
+<script>
+  const { getAlgoliaResults } = window['@algolia/autocomplete-preset-algolia'];
+</script>
 ```
 
 ## Example

--- a/packages/website/docs/getting-started.mdx
+++ b/packages/website/docs/getting-started.mdx
@@ -40,10 +40,13 @@ yarn add @algolia/autocomplete-js@alpha
 npm install @algolia/autocomplete-js@alpha
 ```
 
-If you don't want to use a package manager, you can use a standalone endpoint:
+If you don't use a package manager, you can use the HTML `script` element:
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-js@alpha"></script>
+<script>
+  const { autocomplete } = window['@algolia/autocomplete-js'];
+</script>
 ```
 
 We recommend using [jsDelivr](https://www.jsdelivr.com) but [`autocomplete-js`](autocomplete-js) is also available through [unpkg](https://unpkg.com/@algolia/autocomplete-js@alpha).

--- a/packages/website/docs/parseAlgoliaHitHighlight.md
+++ b/packages/website/docs/parseAlgoliaHitHighlight.md
@@ -26,10 +26,15 @@ Then import it in your project:
 import { parseAlgoliaHitHighlight } from '@algolia/autocomplete-preset-algolia';
 ```
 
-If you don't use a package manager, you can use a standalone endpoint:
+If you don't use a package manager, you can use the HTML `script` element:
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-preset-algolia@alpha"></script>
+<script>
+  const { parseAlgoliaHitHighlight } = window[
+    '@algolia/autocomplete-preset-algolia'
+  ];
+</script>
 ```
 
 ## Examples

--- a/packages/website/docs/parseAlgoliaHitReverseHighlight.md
+++ b/packages/website/docs/parseAlgoliaHitReverseHighlight.md
@@ -26,10 +26,15 @@ Then import it in your project:
 import { parseAlgoliaHitReverseHighlight } from '@algolia/autocomplete-preset-algolia';
 ```
 
-If you don't use a package manager, you can use a standalone endpoint:
+If you don't use a package manager, you can use the HTML `script` element:
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-preset-algolia@alpha"></script>
+<script>
+  const { parseAlgoliaHitReverseHighlight } = window[
+    '@algolia/autocomplete-preset-algolia'
+  ];
+</script>
 ```
 
 ## Examples
@@ -44,8 +49,7 @@ const hit = {
   query: 'zelda switch',
   _highlightResult: {
     query: {
-      value:
-        '__aa-highlight__zelda__/aa-highlight__ switch',
+      value: '__aa-highlight__zelda__/aa-highlight__ switch',
     },
   },
 };
@@ -75,8 +79,7 @@ const hit = {
   _highlightResult: {
     hierarchicalCategories: {
       lvl1: {
-        value:
-          '__aa-highlight__Video__/aa-highlight__ games',
+        value: '__aa-highlight__Video__/aa-highlight__ games',
       },
     },
   },

--- a/packages/website/docs/parseAlgoliaHitReverseSnippet.md
+++ b/packages/website/docs/parseAlgoliaHitReverseSnippet.md
@@ -26,10 +26,15 @@ Then import it in your project:
 import { parseAlgoliaHitReverseSnippet } from '@algolia/autocomplete-preset-algolia';
 ```
 
-If you don't use a package manager, you can use a standalone endpoint:
+If you don't use a package manager, you can use the HTML `script` element:
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-preset-algolia@alpha"></script>
+<script>
+  const { parseAlgoliaHitReverseSnippet } = window[
+    '@algolia/autocomplete-preset-algolia'
+  ];
+</script>
 ```
 
 ## Examples
@@ -44,8 +49,7 @@ const hit = {
   query: 'zelda switch',
   _snippetResult: {
     query: {
-      value:
-        '__aa-highlight__zelda__/aa-highlight__ switch',
+      value: '__aa-highlight__zelda__/aa-highlight__ switch',
     },
   },
 };
@@ -75,8 +79,7 @@ const hit = {
   _snippetResult: {
     hierarchicalCategories: {
       lvl1: {
-        value:
-          '__aa-highlight__Video__/aa-highlight__ games',
+        value: '__aa-highlight__Video__/aa-highlight__ games',
       },
     },
   },

--- a/packages/website/docs/parseAlgoliaHitSnippet.md
+++ b/packages/website/docs/parseAlgoliaHitSnippet.md
@@ -26,10 +26,15 @@ Then import it in your project:
 import { parseAlgoliaHitSnippet } from '@algolia/autocomplete-preset-algolia';
 ```
 
-If you don't use a package manager, you can use a standalone endpoint:
+If you don't use a package manager, you can use the HTML `script` element:
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-preset-algolia@alpha"></script>
+<script>
+  const { parseAlgoliaHitSnippet } = window[
+    '@algolia/autocomplete-preset-algolia'
+  ];
+</script>
 ```
 
 ## Examples


### PR DESCRIPTION
This adds documentation for users that don't use a package manager, but rely on `script` tags.

We need to document how to get the UMD export from the global object since the import is not so straightforward.