### PR TITLE
feat(qs): append space to query on tap-ahead

### DIFF
--- a/packages/autocomplete-plugin-query-suggestions/src/createQuerySuggestionsPlugin.ts
+++ b/packages/autocomplete-plugin-query-suggestions/src/createQuerySuggestionsPlugin.ts
@@ -82,7 +82,7 @@ export function createQuerySuggestionsPlugin<
   return {
     getSources({ query, setQuery, refresh, state }) {
       function onTapAhead(item: TItem) {
-        setQuery(item.query);
+        setQuery(`${item.query} `);
         refresh();
       }
 


### PR DESCRIPTION
When using the tap-ahead pattern on Query Suggestions, it's common to insert a space after the suggestion so that users can keep typing without manually adding a space.