### PR TITLE
fix(classic-theme): remove pointer cursor on no result item content

### DIFF
--- a/cypress/test-apps/js/app.tsx
+++ b/cypress/test-apps/js/app.tsx
@@ -112,9 +112,7 @@ autocomplete({
             );
           },
           noResults() {
-            return (
-              <div className="aa-ItemContent">No products for this query.</div>
-            );
+            return 'No products for this query.';
           },
         },
       },

--- a/examples/playground/app.tsx
+++ b/examples/playground/app.tsx
@@ -114,9 +114,7 @@ autocomplete({
             );
           },
           noResults() {
-            return (
-              <div className="aa-ItemContent">No products for this query.</div>
-            );
+            return 'No products for this query.';
           },
         },
       },

--- a/examples/query-suggestions-with-hits/app.tsx
+++ b/examples/query-suggestions-with-hits/app.tsx
@@ -95,9 +95,7 @@ autocomplete({
             );
           },
           noResults() {
-            return (
-              <div className="aa-ItemContent">No products for this query.</div>
-            );
+            return 'No products for this query.';
           },
         },
       },

--- a/examples/recently-viewed-items/app.tsx
+++ b/examples/recently-viewed-items/app.tsx
@@ -72,9 +72,7 @@ autocomplete({
             );
           },
           noResults() {
-            return (
-              <div className="aa-ItemContent">No products for this query.</div>
-            );
+            return 'No products for this query.';
           },
         },
       },

--- a/packages/autocomplete-theme-classic/src/theme.scss
+++ b/packages/autocomplete-theme-classic/src/theme.scss
@@ -425,9 +425,6 @@ body {
     font-size: 1em;
     margin: 0;
     padding: var(--aa-spacing);
-    .aa-ItemContent {
-      cursor: default;
-    }
   }
   // List of results inside the source
   @at-root .aa-List {

--- a/packages/autocomplete-theme-classic/src/theme.scss
+++ b/packages/autocomplete-theme-classic/src/theme.scss
@@ -425,6 +425,9 @@ body {
     font-size: 1em;
     margin: 0;
     padding: var(--aa-spacing);
+    .aa-ItemContent {
+      cursor: default;
+    }
   }
   // List of results inside the source
   @at-root .aa-List {

--- a/packages/website/docs/autocomplete-theme-classic.md
+++ b/packages/website/docs/autocomplete-theme-classic.md
@@ -151,7 +151,7 @@ autocomplete({
   // ...
   templates: {
     noResults() {
-      return <div className="aa-ItemContent">No results for this query.</div>;
+      return 'No products for this query.';
     },
     // ...
   },


### PR DESCRIPTION
This removes the pointer cursor on the no result item content.

![Capture d’écran 2021-04-13 à 19 01 00 (2)](https://user-images.githubusercontent.com/5370675/114591927-af930580-9c8a-11eb-8e15-768f07eb44d7.png)
