### PR TITLE
docs: document helper methods

### DIFF
--- a/packages/website/docs/autocomplete-js.md
+++ b/packages/website/docs/autocomplete-js.md
@@ -347,3 +347,23 @@ const {
   destroy,
 } = autocomplete(options);
 ```
+
+## Helpers
+
+### `refresh`
+
+> `() => void`
+
+Updates the UI state. You must call this function whenever you mutate the state with setters.
+
+### `update`
+
+> `(updatedOptions: Partial<AutocompleteOptions<TItem>>) => void`
+
+Updates the Autocomplete experience with new options.
+
+### `destroy`
+
+> `() => void`
+
+Destroys the Autocomplete instance, cleans up the DOM mutations and event listeners.

--- a/packages/website/docs/autocomplete-js.md
+++ b/packages/website/docs/autocomplete-js.md
@@ -352,15 +352,15 @@ const {
 
 ### `refresh`
 
-> `() => void`
+> `() => Promise<void>`
 
-Updates the UI state. You must call this function whenever you mutate the state with setters.
+Updates the UI state. You must call this function whenever you mutate the state with setters and want to reflect the changes in the UI.
 
 ### `update`
 
-> `(updatedOptions: Partial<AutocompleteOptions<TItem>>) => void`
+> `(updatedOptions: Partial<AutocompleteOptions>) => void`
 
-Updates the Autocomplete experience with new options.
+Updates the Autocomplete instance with new options.
 
 ### `destroy`
 

--- a/packages/website/docs/autocomplete-js.md
+++ b/packages/website/docs/autocomplete-js.md
@@ -343,5 +343,7 @@ const {
   setStatus,
   setContext,
   refresh,
+  update,
+  destroy,
 } = autocomplete(options);
 ```

--- a/packages/website/docs/createAutocomplete.md
+++ b/packages/website/docs/createAutocomplete.md
@@ -107,3 +107,21 @@ const {
   destroy,
 } = createAutocomplete(options);
 ```
+
+### `refresh`
+
+> `() => void`
+
+Updates the UI state. You must call this function whenever you mutate the state with setters.
+
+### `update`
+
+> `(updatedOptions: Partial<AutocompleteOptions<TItem>>) => void`
+
+Updates the Autocomplete experience with new options.
+
+### `destroy`
+
+> `() => void`
+
+Destroys the Autocomplete instance, cleans up the DOM mutations and event listeners.

--- a/packages/website/docs/createAutocomplete.md
+++ b/packages/website/docs/createAutocomplete.md
@@ -103,5 +103,7 @@ const {
   setStatus,
   setContext,
   refresh,
+  update,
+  destroy,
 } = createAutocomplete(options);
 ```

--- a/packages/website/docs/createAutocomplete.md
+++ b/packages/website/docs/createAutocomplete.md
@@ -118,7 +118,7 @@ Updates the UI state. You must call this function whenever you mutate the state 
 
 > `(updatedOptions: Partial<AutocompleteOptions<TItem>>) => void`
 
-Updates the Autocomplete experience with new options.
+Updates the Autocomplete instance with new options.
 
 ### `destroy`
 

--- a/packages/website/docs/state.md
+++ b/packages/website/docs/state.md
@@ -8,6 +8,7 @@ The state drives the behavior of the autocomplete experience.
 The state is an underlying set of properties that drives the autocomplete behavior. For example, `query` contains the value typed in the search input. As the query changes, the retrieved items from the [sources](/docs/sources) change.
 
 The state contains:
+
 - `query`: the search input value
 - `activeItemId`: which item is active
 - `completion`: the completed version of the query
@@ -174,3 +175,23 @@ Sets the collections of items of the autocomplete.
 Sets the context passed to lifecycle hooks.
 
 See more in [**Context**](context).
+
+## Helpers
+
+### `refresh`
+
+> `() => void`
+
+Updates the UI state. You must call this function whenever you mutate the state with setters.
+
+### `update`
+
+> `(updatedOptions: Partial<AutocompleteOptions<TItem>>) => void`
+
+Updates the Autocomplete experience with new options.
+
+### `destroy`
+
+> `() => void`
+
+Destroys the Autocomplete instance, cleans up the DOM mutations and event listeners.

--- a/packages/website/docs/state.md
+++ b/packages/website/docs/state.md
@@ -175,23 +175,3 @@ Sets the collections of items of the autocomplete.
 Sets the context passed to lifecycle hooks.
 
 See more in [**Context**](context).
-
-## Helpers
-
-### `refresh`
-
-> `() => void`
-
-Updates the UI state. You must call this function whenever you mutate the state with setters.
-
-### `update`
-
-> `(updatedOptions: Partial<AutocompleteOptions<TItem>>) => void`
-
-Updates the Autocomplete experience with new options.
-
-### `destroy`
-
-> `() => void`
-
-Destroys the Autocomplete instance, cleans up the DOM mutations and event listeners.


### PR DESCRIPTION
This document the `refresh`, `update` and `destroy` helpers on the API reference of Autocomplete core and JS.

I didn't create a partial since we'll be moving this to the main docs soon.