### PR TITLE
fix(classic-theme): fix modal display in desktop Detached Mode

### DIFF
--- a/packages/autocomplete-theme-classic/src/theme.scss
+++ b/packages/autocomplete-theme-classic/src/theme.scss
@@ -890,6 +890,7 @@ body {
     .aa-PanelLayout {
       max-height: var(--aa-detached-modal-max-height);
       padding-bottom: var(--aa-spacing-half);
+      position: static;
     }
   }
 }


### PR DESCRIPTION
We had a bug preventing the panel to display at all in desktop Detached Mode. This PR fixes it.

## Next steps

We should have a dedicated demo for desktop Detached Mode, along with visual regression tests to avoid breaking the UI without us knowing.