### PR TITLE
fix(js): compute panel top position with `getBoundingClientRect`

### DIFF
--- a/packages/autocomplete-js/src/__tests__/panelPlacement.test.ts
+++ b/packages/autocomplete-js/src/__tests__/panelPlacement.test.ts
@@ -2,10 +2,8 @@ import { waitFor } from '@testing-library/dom';
 
 import { autocomplete } from '../autocomplete';
 
-// Arbitrary values to mock `getBoundingClientRect`, `offsetTop` and `clientWidth`
+// Arbitrary values to mock `getBoundingClientRect` and `clientWidth`
 // (by default jest mock everything to 0 but we cannot properly check the calculations if everything is set to 0)
-const OFFSET_TOP = 2;
-const CLIENT_WIDTH = 3;
 const BOTTOM = 5;
 const HEIGHT = 7;
 const LEFT = 11;
@@ -28,15 +26,15 @@ describe('panelPlacement', () => {
   });
 
   beforeAll(() => {
-    Object.defineProperty(window.HTMLElement.prototype, 'offsetTop', {
-      get() {
-        return OFFSET_TOP;
-      },
-    });
     Object.defineProperty(document.documentElement, 'clientWidth', {
       get() {
-        return CLIENT_WIDTH;
+        return 1920;
       },
+    });
+    Object.defineProperty(document.documentElement, 'clientHeight', {
+      writable: true,
+      configurable: true,
+      value: 1080,
     });
   });
 
@@ -50,11 +48,6 @@ describe('panelPlacement', () => {
   });
 
   afterAll(() => {
-    Object.defineProperty(window.HTMLElement.prototype, 'offsetTop', {
-      get() {
-        return 0;
-      },
-    });
     Object.defineProperty(document.documentElement, 'clientWidth', {
       get() {
         return 0;
@@ -82,9 +75,9 @@ describe('panelPlacement', () => {
 
       await waitFor(() => {
         expect(document.querySelector('.aa-Panel')).toHaveStyle({
-          top: '9px', // OFFSET_TOP + HEIGHT
+          top: '24px', // TOP + HEIGHT
           left: '11px', // LEFT
-          right: '-27px', // CLIENT_WIDTH - (LEFT + WIDTH)
+          right: '1890px', // CLIENT_WIDTH - (LEFT + WIDTH)
           width: 'unset',
           'max-width': 'unset',
         });
@@ -112,7 +105,7 @@ describe('panelPlacement', () => {
 
       await waitFor(() => {
         expect(document.querySelector('.aa-Panel')).toHaveStyle({
-          top: '9px', // OFFSET_TOP + HEIGHT
+          top: '24px', // TOP + HEIGHT
           left: '11px', // LEFT
         });
       });
@@ -139,8 +132,8 @@ describe('panelPlacement', () => {
 
       await waitFor(() => {
         expect(document.querySelector('.aa-Panel')).toHaveStyle({
-          top: '9px', // OFFSET_TOP + HEIGHT
-          right: '-27px', // CLIENT_WIDTH - (LEFT + WIDTH)
+          top: '24px', // TOP + HEIGHT
+          right: '1890px', // CLIENT_WIDTH - (LEFT + WIDTH)
         });
       });
     });
@@ -166,7 +159,7 @@ describe('panelPlacement', () => {
 
       await waitFor(() => {
         expect(document.querySelector('.aa-Panel')).toHaveStyle({
-          top: '9px', // OFFSET_TOP + HEIGHT
+          top: '24px', // TOP + HEIGHT
           left: 0,
           right: 0,
           width: 'unset',
@@ -194,9 +187,9 @@ describe('panelPlacement', () => {
 
     await waitFor(() => {
       expect(document.querySelector('.aa-Panel')).toHaveStyle({
-        top: '9px', // OFFSET_TOP + HEIGHT
+        top: '24px', // TOP + HEIGHT
         left: '11px', // LEFT
-        right: '-27px', // CLIENT_WIDTH - (LEFT + WIDTH)
+        right: '1890px', // CLIENT_WIDTH - (LEFT + WIDTH)
         width: 'unset',
         'max-width': 'unset',
       });

--- a/packages/autocomplete-js/src/__tests__/positioning.test.ts
+++ b/packages/autocomplete-js/src/__tests__/positioning.test.ts
@@ -84,6 +84,19 @@ describe('Panel positioning', () => {
     });
   });
 
+  afterAll(() => {
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      get() {
+        return 0;
+      },
+    });
+    Object.defineProperty(document.documentElement, 'clientHeight', {
+      get() {
+        return 0;
+      },
+    });
+  });
+
   afterEach(() => {
     document.body.innerHTML = '';
   });
@@ -101,11 +114,6 @@ describe('Panel positioning', () => {
     });
 
     const root = document.querySelector<HTMLDivElement>('.aa-Autocomplete');
-    Object.defineProperty(root, 'offsetTop', {
-      writable: true,
-      configurable: true,
-      value: 40,
-    });
     root.getBoundingClientRect = jest.fn().mockReturnValue(rootPosition);
     const form = document.querySelector<HTMLFormElement>('.aa-Form');
     form.getBoundingClientRect = jest.fn().mockReturnValue(formPosition);
@@ -116,7 +124,7 @@ describe('Panel positioning', () => {
     await waitFor(() => getByTestId(panelContainer, 'panel'));
 
     expect(getByTestId(panelContainer, 'panel')).toHaveStyle({
-      top: '60px',
+      top: '40px',
       left: '300px',
       right: '1020px',
     });
@@ -136,11 +144,6 @@ describe('Panel positioning', () => {
 
     const root = document.querySelector<HTMLDivElement>('.aa-Autocomplete');
     root.getBoundingClientRect = jest.fn().mockReturnValue(rootPosition);
-    Object.defineProperty(root, 'offsetTop', {
-      writable: true,
-      configurable: true,
-      value: 40,
-    });
     const form = document.querySelector<HTMLFormElement>('.aa-Form');
     form.getBoundingClientRect = jest.fn().mockReturnValue(formPosition);
 
@@ -150,7 +153,7 @@ describe('Panel positioning', () => {
     await waitFor(() => getByTestId(panelContainer, 'panel'));
 
     expect(getByTestId(panelContainer, 'panel')).toHaveStyle({
-      top: '60px',
+      top: '40px',
       left: '300px',
       right: '1020px',
     });
@@ -158,11 +161,9 @@ describe('Panel positioning', () => {
     input.blur();
 
     // Move the root vertically
-    Object.defineProperty(root, 'offsetTop', {
-      writable: true,
-      configurable: true,
-      value: 90,
-    });
+    root.getBoundingClientRect = jest
+      .fn()
+      .mockReturnValue({ ...rootPosition, top: 90 });
 
     input.focus();
 

--- a/packages/autocomplete-js/src/getPanelPlacementStyle.ts
+++ b/packages/autocomplete-js/src/getPanelPlacementStyle.ts
@@ -15,7 +15,7 @@ export function getPanelPlacementStyle({
   environment,
 }: GetPanelPlacementStyleParams) {
   const containerRect = container.getBoundingClientRect();
-  const top = container.offsetTop + containerRect.height;
+  const top = containerRect.top + containerRect.height;
 
   switch (panelPlacement) {
     case 'start': {


### PR DESCRIPTION
Close #535 

The autocomplete container's parent element becomes `offsetParent` when there is a css declaration `position:relative`, where `offsetTop` is calculated relative to the parent element and not the actual position of the container in the page.