### PR TITLE
docs(js): add TSDoc for highlight components

### DIFF
--- a/packages/autocomplete-js/src/types/AutocompleteComponents.ts
+++ b/packages/autocomplete-js/src/types/AutocompleteComponents.ts
@@ -25,7 +25,7 @@ export interface AutocompleteComponents extends PublicAutocompleteComponents {
    */
   ReverseSnippet: AutocompleteHighlightComponent;
   /**
-   * Snippet matches in an Algolia hit.
+   * Highlight and snippet matches in an Algolia hit.
    */
   Snippet: AutocompleteHighlightComponent;
 }

--- a/packages/autocomplete-js/src/types/AutocompleteComponents.ts
+++ b/packages/autocomplete-js/src/types/AutocompleteComponents.ts
@@ -12,8 +12,20 @@ export type PublicAutocompleteComponents = Record<
 >;
 
 export interface AutocompleteComponents extends PublicAutocompleteComponents {
+  /**
+   * Highlight matches in an Algolia hit.
+   */
   Highlight: AutocompleteHighlightComponent;
+  /**
+   * Reverse-highlight matches in an Algolia hit.
+   */
   ReverseHighlight: AutocompleteHighlightComponent;
+  /**
+   * Reverse-highlight and snippets matches in an Algolia hit.
+   */
   ReverseSnippet: AutocompleteHighlightComponent;
+  /**
+   * Snippet matches in an Algolia hit.
+   */
   Snippet: AutocompleteHighlightComponent;
 }

--- a/packages/website/docs/autocomplete-js.md
+++ b/packages/website/docs/autocomplete-js.md
@@ -172,7 +172,7 @@ autocomplete({
 Four components are registered by default:
 
 - `Highlight` to highlight matches in an Algolia hit
-- `Snippet` to snippet matches in an Algolia hit
+- `Snippet` to highlight and snippet matches in an Algolia hit
 - `ReverseHighlight` to reverse-highlight matches in an Algolia hit
 - `ReverseSnippet` to reverse-highlight and snippet matches in an Algolia hit
 

--- a/packages/website/docs/autocomplete-js.md
+++ b/packages/website/docs/autocomplete-js.md
@@ -171,10 +171,10 @@ autocomplete({
 
 Four components are registered by default:
 
-- `Highlight` to highlight matches in Algolia results
-- `Snippet` to snippet matches in Algolia results
-- `ReverseHighlight` to reverse highlight matches in Algolia results
-- `ReverseSnippet` to reverse highlight and snippet matches in Algolia results
+- `Highlight` to highlight matches in an Algolia hit
+- `Snippet` to snippet matches in an Algolia hit
+- `ReverseHighlight` to reverse-highlight matches in an Algolia hit
+- `ReverseSnippet` to reverse-highlight and snippet matches in an Algolia hit
 
 ```jsx
 autocomplete({


### PR DESCRIPTION
The TSDoc description for the highlight components was missing.