### PR TITLE
fix(examples): update build command

### DIFF
--- a/examples/github-repositories-custom-plugin/package.json
+++ b/examples/github-repositories-custom-plugin/package.json
@@ -4,9 +4,8 @@
   "version": "1.0.0-alpha.45",
   "private": true,
   "license": "MIT",
-  "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html --dist-dir ./dist",
+    "build": "parcel build index.html",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/github-repositories-custom-plugin/package.json
+++ b/examples/github-repositories-custom-plugin/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html",
+    "build": "parcel build index.html --dist-dir ./dist",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/multiple-datasets-with-headers/package.json
+++ b/examples/multiple-datasets-with-headers/package.json
@@ -4,9 +4,8 @@
   "version": "1.0.0-alpha.45",
   "private": true,
   "license": "MIT",
-  "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html --dist-dir ./dist",
+    "build": "parcel build index.html",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/multiple-datasets-with-headers/package.json
+++ b/examples/multiple-datasets-with-headers/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html",
+    "build": "parcel build index.html --dist-dir ./dist",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -4,9 +4,8 @@
   "version": "1.0.0-alpha.45",
   "private": true,
   "license": "MIT",
-  "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html --dist-dir ./dist",
+    "build": "parcel build index.html",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html",
+    "build": "parcel build index.html --dist-dir ./dist",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/query-suggestions-with-categories/package.json
+++ b/examples/query-suggestions-with-categories/package.json
@@ -4,9 +4,8 @@
   "version": "1.0.0-alpha.45",
   "private": true,
   "license": "MIT",
-  "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html --dist-dir ./dist",
+    "build": "parcel build index.html",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/query-suggestions-with-categories/package.json
+++ b/examples/query-suggestions-with-categories/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html",
+    "build": "parcel build index.html --dist-dir ./dist",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/query-suggestions-with-hits/package.json
+++ b/examples/query-suggestions-with-hits/package.json
@@ -4,9 +4,8 @@
   "version": "1.0.0-alpha.45",
   "private": true,
   "license": "MIT",
-  "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html --dist-dir ./dist",
+    "build": "parcel build index.html",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/query-suggestions-with-hits/package.json
+++ b/examples/query-suggestions-with-hits/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html",
+    "build": "parcel build index.html --dist-dir ./dist",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/query-suggestions-with-inline-categories/package.json
+++ b/examples/query-suggestions-with-inline-categories/package.json
@@ -4,9 +4,8 @@
   "version": "1.0.0-alpha.45",
   "private": true,
   "license": "MIT",
-  "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html --dist-dir ./dist",
+    "build": "parcel build index.html",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/query-suggestions-with-inline-categories/package.json
+++ b/examples/query-suggestions-with-inline-categories/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html",
+    "build": "parcel build index.html --dist-dir ./dist",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/query-suggestions-with-recent-searches-and-categories/package.json
+++ b/examples/query-suggestions-with-recent-searches-and-categories/package.json
@@ -4,9 +4,8 @@
   "version": "1.0.0-alpha.45",
   "private": true,
   "license": "MIT",
-  "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html --dist-dir ./dist",
+    "build": "parcel build index.html",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/query-suggestions-with-recent-searches-and-categories/package.json
+++ b/examples/query-suggestions-with-recent-searches-and-categories/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html",
+    "build": "parcel build index.html --dist-dir ./dist",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/query-suggestions-with-recent-searches/package.json
+++ b/examples/query-suggestions-with-recent-searches/package.json
@@ -4,9 +4,8 @@
   "version": "1.0.0-alpha.45",
   "private": true,
   "license": "MIT",
-  "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html --dist-dir ./dist",
+    "build": "parcel build index.html",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/query-suggestions-with-recent-searches/package.json
+++ b/examples/query-suggestions-with-recent-searches/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html",
+    "build": "parcel build index.html --dist-dir ./dist",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/query-suggestions/package.json
+++ b/examples/query-suggestions/package.json
@@ -4,9 +4,8 @@
   "version": "1.0.0-alpha.45",
   "private": true,
   "license": "MIT",
-  "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html --dist-dir ./dist",
+    "build": "parcel build index.html",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/query-suggestions/package.json
+++ b/examples/query-suggestions/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html",
+    "build": "parcel build index.html --dist-dir ./dist",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/recently-viewed-items/package.json
+++ b/examples/recently-viewed-items/package.json
@@ -4,9 +4,8 @@
   "version": "1.0.0-alpha.45",
   "private": true,
   "license": "MIT",
-  "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html --dist-dir ./dist",
+    "build": "parcel build index.html",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/starter-algolia/package.json
+++ b/examples/starter-algolia/package.json
@@ -4,9 +4,8 @@
   "version": "1.0.0-alpha.45",
   "private": true,
   "license": "MIT",
-  "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html --dist-dir ./dist",
+    "build": "parcel build index.html",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/starter-algolia/package.json
+++ b/examples/starter-algolia/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html",
+    "build": "parcel build index.html --dist-dir ./dist",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/starter/package.json
+++ b/examples/starter/package.json
@@ -4,9 +4,8 @@
   "version": "1.0.0-alpha.45",
   "private": true,
   "license": "MIT",
-  "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html --dist-dir ./dist",
+    "build": "parcel build index.html",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/starter/package.json
+++ b/examples/starter/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html",
+    "build": "parcel build index.html --dist-dir ./dist",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/voice-search/package.json
+++ b/examples/voice-search/package.json
@@ -4,9 +4,8 @@
   "version": "1.0.0-alpha.45",
   "private": true,
   "license": "MIT",
-  "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html --dist-dir ./dist",
+    "build": "parcel build index.html",
     "start": "parcel index.html"
   },
   "dependencies": {

--- a/examples/voice-search/package.json
+++ b/examples/voice-search/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "index.html",
   "scripts": {
-    "build": "parcel build index.html",
+    "build": "parcel build index.html --dist-dir ./dist",
     "start": "parcel index.html"
   },
   "dependencies": {


### PR DESCRIPTION
**Summary**

Updates parcel 2 build command.
The `main` prop overrides the default `build` location (which is `./dist`)

[`main` usage](https://github.com/parcel-bundler/parcel/discussions/3377#discussioncomment-15960)
[parcel v2 `build`](https://v2.parceljs.org/features/cli/#parcel-build-%3Centries%3E)