### PR TITLE
fix: update examples and tests with Requester API

### DIFF
--- a/cypress/test-apps/js/app.tsx
+++ b/cypress/test-apps/js/app.tsx
@@ -2,7 +2,7 @@
 import {
   autocomplete,
   AutocompleteComponents,
-  getAlgoliaHits,
+  getAlgoliaResults,
 } from '@algolia/autocomplete-js';
 import {
   AutocompleteInsightsApi,
@@ -78,7 +78,7 @@ autocomplete({
       {
         sourceId: 'products',
         getItems() {
-          return getAlgoliaHits<Product>({
+          return getAlgoliaResults<Product>({
             searchClient,
             queries: [
               {

--- a/examples/query-suggestions-with-hits/app.tsx
+++ b/examples/query-suggestions-with-hits/app.tsx
@@ -2,7 +2,7 @@
 import {
   autocomplete,
   AutocompleteComponents,
-  getAlgoliaHits,
+  getAlgoliaResults,
 } from '@algolia/autocomplete-js';
 import {
   AutocompleteInsightsApi,
@@ -50,7 +50,7 @@ autocomplete<ProductHit>({
       {
         sourceId: 'products',
         getItems() {
-          return getAlgoliaHits<ProductHit>({
+          return getAlgoliaResults<ProductHit>({
             searchClient,
             queries: [
               {

--- a/examples/react-renderer/src/Autocomplete.tsx
+++ b/examples/react-renderer/src/Autocomplete.tsx
@@ -3,7 +3,7 @@ import {
   AutocompleteState,
   createAutocomplete,
 } from '@algolia/autocomplete-core';
-import { getAlgoliaHits } from '@algolia/autocomplete-preset-algolia';
+import { getAlgoliaResults } from '@algolia/autocomplete-preset-algolia';
 import { Hit } from '@algolia/client-search';
 import algoliasearch from 'algoliasearch/lite';
 import React from 'react';
@@ -54,7 +54,7 @@ export function Autocomplete(
             {
               sourceId: 'products',
               getItems({ query }) {
-                return getAlgoliaHits({
+                return getAlgoliaResults({
                   searchClient,
                   queries: [
                     {

--- a/examples/recently-viewed-items/app.tsx
+++ b/examples/recently-viewed-items/app.tsx
@@ -2,7 +2,7 @@
 import {
   autocomplete,
   AutocompleteComponents,
-  getAlgoliaHits,
+  getAlgoliaResults,
 } from '@algolia/autocomplete-js';
 import algoliasearch from 'algoliasearch';
 import { h, Fragment } from 'preact';
@@ -35,7 +35,7 @@ autocomplete<ProductHit>({
       {
         sourceId: 'products',
         getItems() {
-          return getAlgoliaHits<ProductHit>({
+          return getAlgoliaResults<ProductHit>({
             searchClient,
             queries: [
               {

--- a/examples/starter-algolia/app.tsx
+++ b/examples/starter-algolia/app.tsx
@@ -1,5 +1,5 @@
 /** @jsx h */
-import { autocomplete, getAlgoliaHits } from '@algolia/autocomplete-js';
+import { autocomplete, getAlgoliaResults } from '@algolia/autocomplete-js';
 import { Hit } from '@algolia/client-search';
 import algoliasearch from 'algoliasearch';
 import { h } from 'preact';
@@ -30,7 +30,7 @@ autocomplete<AutocompleteItem>({
       {
         sourceId: 'products',
         getItems() {
-          return getAlgoliaHits<AutocompleteItem>({
+          return getAlgoliaResults<AutocompleteItem>({
             searchClient,
             queries: [
               {

--- a/examples/voice-search/app.tsx
+++ b/examples/voice-search/app.tsx
@@ -1,5 +1,5 @@
 /** @jsx h */
-import { autocomplete, getAlgoliaHits } from '@algolia/autocomplete-js';
+import { autocomplete, getAlgoliaResults } from '@algolia/autocomplete-js';
 import { Hit } from '@algolia/client-search';
 import algoliasearch from 'algoliasearch';
 import { h } from 'preact';
@@ -35,7 +35,7 @@ autocomplete<AutocompleteItem>({
       {
         sourceId: 'products',
         getItems() {
-          return getAlgoliaHits<AutocompleteItem>({
+          return getAlgoliaResults<AutocompleteItem>({
             searchClient,
             queries: [
               {

--- a/packages/autocomplete-core/src/getAutocompleteSetters.ts
+++ b/packages/autocomplete-core/src/getAutocompleteSetters.ts
@@ -29,7 +29,7 @@ export function getAutocompleteSetters<TItem extends BaseItem>({
     let baseItemId = 0;
     const value = rawValue.map<AutocompleteCollection<TItem>>((collection) => ({
       ...collection,
-      // We flatten the stored items to support calling `getAlgoliaHits`
+      // We flatten the stored items to support calling `getAlgoliaResults`
       // from the source itself.
       items: flatten(collection.items as any).map((item: any) => ({
         ...item,


### PR DESCRIPTION
There were examples and tests still using the old API. This fixes it.