### PR TITLE
test: better test getAlgoliaResults

### DIFF
--- a/packages/autocomplete-js/src/requesters/__tests__/getAlgoliaResults.test.ts
+++ b/packages/autocomplete-js/src/requesters/__tests__/getAlgoliaResults.test.ts
@@ -1,0 +1,82 @@
+import { createSearchClient } from '../../../../../test/utils';
+import { getAlgoliaResults } from '../getAlgoliaResults';
+
+describe('getAlgoliaResults', () => {
+  test('returns the description', () => {
+    const searchClient = createSearchClient({
+      search: jest.fn(),
+    });
+    const description = getAlgoliaResults({
+      searchClient,
+      queries: [
+        {
+          indexName: 'indexName',
+          query: 'query',
+        },
+        {
+          indexName: 'indexName2',
+          query: 'query',
+        },
+      ],
+    });
+
+    expect(description).toEqual({
+      execute: expect.any(Function),
+      transformResponse: expect.any(Function),
+      searchClient,
+      queries: [
+        {
+          indexName: 'indexName',
+          query: 'query',
+        },
+        {
+          indexName: 'indexName2',
+          query: 'query',
+        },
+      ],
+    });
+  });
+
+  test('defaults transformItems to retrieve hits', async () => {
+    const searchClient = createSearchClient({
+      search: jest.fn(),
+    });
+    const description = getAlgoliaResults<{ label: string }>({
+      searchClient,
+      queries: [
+        {
+          indexName: 'indexName',
+          query: 'query',
+        },
+      ],
+    });
+
+    const transformedResponse = description.transformResponse({
+      results: [],
+      hits: [
+        [
+          {
+            objectID: '1',
+            label: 'Label',
+            _highlightResult: {
+              label: { value: 'Label', matchLevel: 'none', matchedWords: [] },
+            },
+          },
+        ],
+      ],
+      facetHits: [],
+    });
+
+    expect(transformedResponse).toEqual([
+      [
+        {
+          objectID: '1',
+          label: 'Label',
+          _highlightResult: {
+            label: { value: 'Label', matchLevel: 'none', matchedWords: [] },
+          },
+        },
+      ],
+    ]);
+  });
+});

--- a/packages/autocomplete-js/src/requesters/__tests__/getAlgoliaResults.test.ts
+++ b/packages/autocomplete-js/src/requesters/__tests__/getAlgoliaResults.test.ts
@@ -37,7 +37,7 @@ describe('getAlgoliaResults', () => {
     });
   });
 
-  test('defaults transformItems to retrieve hits', async () => {
+  test('defaults transformItems to retrieve hits', () => {
     const searchClient = createSearchClient({
       search: jest.fn(),
     });

--- a/packages/autocomplete-preset-algolia/src/requester/__tests__/getAlgoliaResults.test.ts
+++ b/packages/autocomplete-preset-algolia/src/requester/__tests__/getAlgoliaResults.test.ts
@@ -2,11 +2,11 @@ import { createSearchClient } from '../../../../../test/utils';
 import { getAlgoliaResults } from '../getAlgoliaResults';
 
 describe('getAlgoliaResults', () => {
-  test('returns the description', async () => {
+  test('returns the description', () => {
     const searchClient = createSearchClient({
       search: jest.fn(),
     });
-    const description = await getAlgoliaResults({
+    const description = getAlgoliaResults({
       searchClient,
       queries: [
         {
@@ -41,7 +41,7 @@ describe('getAlgoliaResults', () => {
     const searchClient = createSearchClient({
       search: jest.fn(),
     });
-    const description = await getAlgoliaResults<{ label: string }>({
+    const description = getAlgoliaResults<{ label: string }>({
       searchClient,
       queries: [
         {

--- a/packages/autocomplete-preset-algolia/src/requester/__tests__/getAlgoliaResults.test.ts
+++ b/packages/autocomplete-preset-algolia/src/requester/__tests__/getAlgoliaResults.test.ts
@@ -37,7 +37,7 @@ describe('getAlgoliaResults', () => {
     });
   });
 
-  test('defaults transformItems to retrieve hits', async () => {
+  test('defaults transformItems to retrieve hits', () => {
     const searchClient = createSearchClient({
       search: jest.fn(),
     });


### PR DESCRIPTION
This adds unit tests for `getAlgoliaResults` in `autocomplete-js` and refactors the ones in `autocomplet-preset-algolia`.