### PR TITLE
fix(theme-classic): various fixes

### DIFF
--- a/packages/autocomplete-theme-classic/src/theme.scss
+++ b/packages/autocomplete-theme-classic/src/theme.scss
@@ -983,6 +983,8 @@ body {
     rgba(var(--aa-background-color-rgb), 0),
     rgba(var(--aa-background-color-rgb), 1)
   );
+  border-bottom-left-radius: calc(var(--aa-spacing) / 4);
+  border-bottom-right-radius: calc(var(--aa-spacing) / 4);
   bottom: 0;
 }
 

--- a/packages/autocomplete-theme-classic/src/theme.scss
+++ b/packages/autocomplete-theme-classic/src/theme.scss
@@ -966,7 +966,7 @@ body {
   left: 0;
   pointer-events: none;
   position: absolute;
-  right: var(--aa-scrollbar-width);
+  right: 0;
   z-index: var(--aa-base-z-index);
 }
 

--- a/packages/autocomplete-theme-classic/src/theme.scss
+++ b/packages/autocomplete-theme-classic/src/theme.scss
@@ -503,6 +503,7 @@ body {
   align-items: center;
   border-radius: 3px;
   cursor: pointer;
+  display: grid;
   min-height: calc(var(--aa-spacing) * 2.5);
   padding: calc(var(--aa-spacing-half) / 2);
   // When the result is active


### PR DESCRIPTION
This PR fixes small visual issues in the theme:

- Vertical alignment of items
- Bottom gradient cut on non-Webkit browsers (not supporting the scrollbar customization)
- Bottom gradient not rounded on Safari

## Vertical alignment of items

### Before

![Capture d’écran 2021-04-23 à 17 26 57](https://user-images.githubusercontent.com/5370675/115894084-2b463c80-a459-11eb-982f-2a7b8429e6e4.png)

### After

![Capture d’écran 2021-04-23 à 17 26 11](https://user-images.githubusercontent.com/5370675/115894104-300af080-a459-11eb-90e1-aba56918aa45.png)

## Bottom gradient cut on non Webkit browsers

### Before

![Capture d’écran 2021-04-23 à 16 53 09](https://user-images.githubusercontent.com/5370675/115893743-d7d3ee80-a458-11eb-8d8d-7eb4e1cf4b71.png)

### After

![Capture d’écran 2021-04-23 à 16 54 13](https://user-images.githubusercontent.com/5370675/115893807-e7533780-a458-11eb-8e52-39028e473ace.png)

## Bottom gradient not rounded on Safari

### Before

![Capture d’écran 2021-04-23 à 17 21 56](https://user-images.githubusercontent.com/5370675/115893840-ef12dc00-a458-11eb-9540-d6451b1bec1f.png)

### After

![Capture d’écran 2021-04-23 à 17 20 52](https://user-images.githubusercontent.com/5370675/115893862-f3d79000-a458-11eb-8e8d-48b45e0f4dcc.png)
