### PR TITLE
chore(deps): update algoliasearch to 4.9.1

### DIFF
--- a/cypress/test-apps/js/package.json
+++ b/cypress/test-apps/js/package.json
@@ -16,8 +16,8 @@
     "@algolia/autocomplete-plugin-recent-searches": "1.0.0-alpha.44",
     "@algolia/autocomplete-preset-algolia": "1.0.0-alpha.44",
     "@algolia/autocomplete-theme-classic": "1.0.0-alpha.44",
-    "@algolia/client-search": "4.9.0",
-    "algoliasearch": "4.9.0",
+    "@algolia/client-search": "4.9.1",
+    "algoliasearch": "4.9.1",
     "preact": "10.5.13",
     "search-insights": "1.7.1"
   },

--- a/examples/instantsearch/package.json
+++ b/examples/instantsearch/package.json
@@ -13,8 +13,8 @@
     "@algolia/autocomplete-plugin-query-suggestions": "1.0.0-alpha.46",
     "@algolia/autocomplete-plugin-recent-searches": "1.0.0-alpha.46",
     "@algolia/autocomplete-theme-classic": "1.0.0-alpha.46",
-    "@algolia/client-search": "4.9.0",
-    "algoliasearch": "4.9.0",
+    "@algolia/client-search": "4.9.1",
+    "algoliasearch": "4.9.1",
     "instantsearch.js": "4.21.0",
     "preact": "10.5.13"
   },

--- a/examples/multiple-datasets-with-headers/package.json
+++ b/examples/multiple-datasets-with-headers/package.json
@@ -13,7 +13,7 @@
     "@algolia/autocomplete-plugin-query-suggestions": "1.0.0-alpha.46",
     "@algolia/autocomplete-plugin-recent-searches": "1.0.0-alpha.46",
     "@algolia/autocomplete-theme-classic": "1.0.0-alpha.46",
-    "algoliasearch": "4.9.0",
+    "algoliasearch": "4.9.1",
     "preact": "10.5.13"
   },
   "devDependencies": {

--- a/examples/panel-placement/package.json
+++ b/examples/panel-placement/package.json
@@ -12,11 +12,11 @@
     "@algolia/autocomplete-js": "1.0.0-alpha.46",
     "@algolia/autocomplete-core": "1.0.0-alpha.46",
     "@algolia/autocomplete-theme-classic": "1.0.0-alpha.46",
-    "algoliasearch": "4.9.0",
+    "algoliasearch": "4.9.1",
     "preact": "10.5.13"
   },
   "devDependencies": {
-    "@algolia/client-search": "4.9.0",
+    "@algolia/client-search": "4.9.1",
     "parcel": "2.0.0-beta.2"
   },
   "keywords": [

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -15,8 +15,8 @@
     "@algolia/autocomplete-plugin-recent-searches": "1.0.0-alpha.46",
     "@algolia/autocomplete-preset-algolia": "1.0.0-alpha.46",
     "@algolia/autocomplete-theme-classic": "1.0.0-alpha.46",
-    "@algolia/client-search": "4.9.0",
-    "algoliasearch": "4.9.0",
+    "@algolia/client-search": "4.9.1",
+    "algoliasearch": "4.9.1",
     "preact": "10.5.13",
     "search-insights": "1.7.1"
   },

--- a/examples/preview-panel-in-modal/package.json
+++ b/examples/preview-panel-in-modal/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@algolia/autocomplete-js": "1.0.0-alpha.46",
     "@algolia/autocomplete-theme-classic": "1.0.0-alpha.46",
-    "algoliasearch": "4.9.0",
+    "algoliasearch": "4.9.1",
     "preact": "10.5.13",
     "qs": "6.10.1"
   },

--- a/examples/query-suggestions-with-categories/package.json
+++ b/examples/query-suggestions-with-categories/package.json
@@ -12,7 +12,7 @@
     "@algolia/autocomplete-js": "1.0.0-alpha.46",
     "@algolia/autocomplete-plugin-query-suggestions": "1.0.0-alpha.46",
     "@algolia/autocomplete-theme-classic": "1.0.0-alpha.46",
-    "algoliasearch": "4.9.0",
+    "algoliasearch": "4.9.1",
     "preact": "10.5.13"
   },
   "devDependencies": {

--- a/examples/query-suggestions-with-hits/package.json
+++ b/examples/query-suggestions-with-hits/package.json
@@ -15,8 +15,8 @@
     "@algolia/autocomplete-plugin-recent-searches": "1.0.0-alpha.46",
     "@algolia/autocomplete-preset-algolia": "1.0.0-alpha.46",
     "@algolia/autocomplete-theme-classic": "1.0.0-alpha.46",
-    "@algolia/client-search": "4.9.0",
-    "algoliasearch": "4.9.0",
+    "@algolia/client-search": "4.9.1",
+    "algoliasearch": "4.9.1",
     "preact": "10.5.13",
     "search-insights": "1.7.1"
   },

--- a/examples/query-suggestions-with-inline-categories/package.json
+++ b/examples/query-suggestions-with-inline-categories/package.json
@@ -12,7 +12,7 @@
     "@algolia/autocomplete-js": "1.0.0-alpha.46",
     "@algolia/autocomplete-plugin-query-suggestions": "1.0.0-alpha.46",
     "@algolia/autocomplete-theme-classic": "1.0.0-alpha.46",
-    "algoliasearch": "4.9.0",
+    "algoliasearch": "4.9.1",
     "preact": "10.5.13"
   },
   "devDependencies": {

--- a/examples/query-suggestions-with-recent-searches-and-categories/package.json
+++ b/examples/query-suggestions-with-recent-searches-and-categories/package.json
@@ -13,8 +13,8 @@
     "@algolia/autocomplete-plugin-query-suggestions": "1.0.0-alpha.46",
     "@algolia/autocomplete-plugin-recent-searches": "1.0.0-alpha.46",
     "@algolia/autocomplete-theme-classic": "1.0.0-alpha.46",
-    "@algolia/client-search": "4.9.0",
-    "algoliasearch": "4.9.0",
+    "@algolia/client-search": "4.9.1",
+    "algoliasearch": "4.9.1",
     "preact": "10.5.13"
   },
   "devDependencies": {

--- a/examples/query-suggestions-with-recent-searches/package.json
+++ b/examples/query-suggestions-with-recent-searches/package.json
@@ -13,7 +13,7 @@
     "@algolia/autocomplete-plugin-query-suggestions": "1.0.0-alpha.46",
     "@algolia/autocomplete-plugin-recent-searches": "1.0.0-alpha.46",
     "@algolia/autocomplete-theme-classic": "1.0.0-alpha.46",
-    "algoliasearch": "4.9.0",
+    "algoliasearch": "4.9.1",
     "preact": "10.5.13"
   },
   "devDependencies": {

--- a/examples/query-suggestions/package.json
+++ b/examples/query-suggestions/package.json
@@ -12,7 +12,7 @@
     "@algolia/autocomplete-js": "1.0.0-alpha.46",
     "@algolia/autocomplete-plugin-query-suggestions": "1.0.0-alpha.46",
     "@algolia/autocomplete-theme-classic": "1.0.0-alpha.46",
-    "algoliasearch": "4.9.0",
+    "algoliasearch": "4.9.1",
     "preact": "10.5.13"
   },
   "devDependencies": {

--- a/examples/react-renderer/package.json
+++ b/examples/react-renderer/package.json
@@ -7,8 +7,8 @@
     "@algolia/autocomplete-core": "1.0.0-alpha.46",
     "@algolia/autocomplete-preset-algolia": "1.0.0-alpha.46",
     "@algolia/autocomplete-theme-classic": "1.0.0-alpha.46",
-    "@algolia/client-search": "4.9.0",
-    "algoliasearch": "4.9.0",
+    "@algolia/client-search": "4.9.1",
+    "algoliasearch": "4.9.1",
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-scripts": "4.0.1"

--- a/examples/recently-viewed-items/package.json
+++ b/examples/recently-viewed-items/package.json
@@ -12,8 +12,8 @@
     "@algolia/autocomplete-js": "1.0.0-alpha.46",
     "@algolia/autocomplete-plugin-recent-searches": "1.0.0-alpha.46",
     "@algolia/autocomplete-theme-classic": "1.0.0-alpha.46",
-    "@algolia/client-search": "4.9.0",
-    "algoliasearch": "4.9.0",
+    "@algolia/client-search": "4.9.1",
+    "algoliasearch": "4.9.1",
     "preact": "10.5.13"
   },
   "devDependencies": {

--- a/examples/starter-algolia/package.json
+++ b/examples/starter-algolia/package.json
@@ -11,11 +11,11 @@
   "dependencies": {
     "@algolia/autocomplete-js": "1.0.0-alpha.46",
     "@algolia/autocomplete-theme-classic": "1.0.0-alpha.46",
-    "algoliasearch": "4.9.0",
+    "algoliasearch": "4.9.1",
     "preact": "10.5.13"
   },
   "devDependencies": {
-    "@algolia/client-search": "4.9.0",
+    "@algolia/client-search": "4.9.1",
     "parcel": "2.0.0-beta.2"
   },
   "keywords": [

--- a/examples/voice-search/package.json
+++ b/examples/voice-search/package.json
@@ -11,11 +11,11 @@
   "dependencies": {
     "@algolia/autocomplete-js": "1.0.0-alpha.46",
     "@algolia/autocomplete-theme-classic": "1.0.0-alpha.46",
-    "algoliasearch": "4.9.0",
+    "algoliasearch": "4.9.1",
     "preact": "10.5.13"
   },
   "devDependencies": {
-    "@algolia/client-search": "4.9.0",
+    "@algolia/client-search": "4.9.1",
     "parcel": "2.0.0-beta.2"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@types/react-dom": "^17.0.0",
     "@typescript-eslint/eslint-plugin": "2.19.0",
     "@typescript-eslint/parser": "2.19.0",
-    "algoliasearch": "4.9.0",
+    "algoliasearch": "4.9.1",
     "autoprefixer": "10.0.4",
     "babel-eslint": "10.1.0",
     "babel-loader": "8.2.2",

--- a/packages/autocomplete-core/package.json
+++ b/packages/autocomplete-core/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@algolia/autocomplete-preset-algolia": "1.0.0-alpha.46",
-    "@algolia/client-search": "4.9.0",
-    "algoliasearch": "4.9.0"
+    "@algolia/client-search": "4.9.1",
+    "algoliasearch": "4.9.1"
   }
 }

--- a/packages/autocomplete-js/package.json
+++ b/packages/autocomplete-js/package.json
@@ -37,7 +37,7 @@
     "preact": "^10.0.0"
   },
   "devDependencies": {
-    "@algolia/client-search": "4.9.0"
+    "@algolia/client-search": "4.9.1"
   },
   "peerDependencies": {
     "@algolia/client-search": "^4.5.1"

--- a/packages/autocomplete-plugin-query-suggestions/package.json
+++ b/packages/autocomplete-plugin-query-suggestions/package.json
@@ -37,11 +37,11 @@
     "@algolia/autocomplete-shared": "1.0.0-alpha.46"
   },
   "devDependencies": {
-    "@algolia/client-search": "4.9.0",
-    "algoliasearch": "4.9.0"
+    "@algolia/client-search": "4.9.1",
+    "algoliasearch": "4.9.1"
   },
   "peerDependencies": {
-    "@algolia/client-search": "^4.9.0",
-    "algoliasearch": "^4.9.0"
+    "@algolia/client-search": "^4.9.1",
+    "algoliasearch": "^4.9.1"
   }
 }

--- a/packages/autocomplete-plugin-recent-searches/package.json
+++ b/packages/autocomplete-plugin-recent-searches/package.json
@@ -37,7 +37,7 @@
     "@algolia/autocomplete-shared": "1.0.0-alpha.46"
   },
   "devDependencies": {
-    "@algolia/client-search": "4.9.0"
+    "@algolia/client-search": "4.9.1"
   },
   "peerDependencies": {
     "@algolia/client-search": "^4.5.1"

--- a/packages/autocomplete-preset-algolia/package.json
+++ b/packages/autocomplete-preset-algolia/package.json
@@ -34,11 +34,11 @@
     "@algolia/autocomplete-shared": "1.0.0-alpha.46"
   },
   "devDependencies": {
-    "@algolia/client-search": "4.9.0",
-    "algoliasearch": "4.9.0"
+    "@algolia/client-search": "4.9.1",
+    "algoliasearch": "4.9.1"
   },
   "peerDependencies": {
-    "@algolia/client-search": "^4.9.0",
-    "algoliasearch": "^4.9.0"
+    "@algolia/client-search": "^4.9.1",
+    "algoliasearch": "^4.9.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,22 +71,22 @@
   dependencies:
     "@algolia/cache-common" "4.8.6"
 
-"@algolia/cache-browser-local-storage@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.9.0.tgz#9adf95a143b71219b24fa2874de771b58109c9c2"
-  integrity sha512-H659baxPygLp1ed5Y+kko9nLhhTRtZ6v2k2cs2/WTErAd6XU+OrvTvsEedUprDYUve/t9NLg95Ka9TK8QEQk1w==
+"@algolia/cache-browser-local-storage@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.9.1.tgz#784e91580dcca00a8280b0905197f5abbbdf4b48"
+  integrity sha512-bAUU9vKCy45uTTlzJw0LYu1IjoZsmzL6lgjaVFaW1crhX/4P+JD5ReQv3n/wpiXSFaHq1WEO3WyH2g3ymzeipQ==
   dependencies:
-    "@algolia/cache-common" "4.9.0"
+    "@algolia/cache-common" "4.9.1"
 
 "@algolia/cache-common@4.8.6":
   version "4.8.6"
   resolved "https://registry.yarnpkg.com/@algolia/cache-common/-/cache-common-4.8.6.tgz#dff1697a0fe3d7856630071559661ec5ad90f31c"
   integrity sha512-eGQlsXU5G7n4RvV/K6qe6lRAeL6EKAYPT3yZDBjCW4pAh7JWta+77a7BwUQkTqXN1MEQWZXjex3E4z/vFpzNrg==
 
-"@algolia/cache-common@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@algolia/cache-common/-/cache-common-4.9.0.tgz#ec63d71ec201d0d9eb9946bc58f10e430e982b7b"
-  integrity sha512-hBqkLEw1Y7oxEJEVmcdm/s/+KKlvCmSenlX5rrQts5qCNdhdS1QkCvHx8vgFF9J6uliP2TPs+umrrXc+aKsLPw==
+"@algolia/cache-common@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-common/-/cache-common-4.9.1.tgz#2d5f37ba7aab7db76627c4a4fce51a7fd137fa65"
+  integrity sha512-tcvw4mOfFy44V4ZxDEy9wNGr6vFROZKRpXKTEBgdw/WBn6mX51H1ar4RWtceDEcDU4H5fIv5tsY3ip2hU+fTPg==
 
 "@algolia/cache-in-memory@4.8.6":
   version "4.8.6"
@@ -95,12 +95,12 @@
   dependencies:
     "@algolia/cache-common" "4.8.6"
 
-"@algolia/cache-in-memory@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@algolia/cache-in-memory/-/cache-in-memory-4.9.0.tgz#14287235b7eff46c0c3dae2f05e7816805948804"
-  integrity sha512-8q9z8tkIrgPenZl+aTc6MOQleLnanVy+Nsz7Uzga5r9Kb7xpqYKNI9rSJYyBzl7KRxock5v6AOUiFgi45eDnDg==
+"@algolia/cache-in-memory@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-in-memory/-/cache-in-memory-4.9.1.tgz#3fd1d67aec804b6cc8439015b8b9c712a45c7ae0"
+  integrity sha512-IEJrHonvdymW2CnRfJtsTVWyfAH05xPEFkGXGCw00+6JNCj8Dln3TeaRLiaaY1srlyGedkemekQm1/Xb46CGOQ==
   dependencies:
-    "@algolia/cache-common" "4.9.0"
+    "@algolia/cache-common" "4.9.1"
 
 "@algolia/client-account@4.8.6":
   version "4.8.6"
@@ -111,14 +111,14 @@
     "@algolia/client-search" "4.8.6"
     "@algolia/transporter" "4.8.6"
 
-"@algolia/client-account@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@algolia/client-account/-/client-account-4.9.0.tgz#bf8c23d8c7ff9bfa08b480fa27f96cfb489f3263"
-  integrity sha512-u9cljyqUnlgHIKazeOA2R820pDZFReRVm3AObiGrxhdKVQ44ZOgAlN+NIqA+c19iFdpulzpkPKxU+Uavcky7JQ==
+"@algolia/client-account@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@algolia/client-account/-/client-account-4.9.1.tgz#f2c1b3e49de2ee1fca44b8b5e64e1ce0dbdff0db"
+  integrity sha512-Shpjeuwb7i2LR5QuWREb6UbEQLGB+Pl/J5+wPgILJDP/uWp7jpl0ase9mYNQGKj7TjztpSpQCPZ3dSHPnzZPfw==
   dependencies:
-    "@algolia/client-common" "4.9.0"
-    "@algolia/client-search" "4.9.0"
-    "@algolia/transporter" "4.9.0"
+    "@algolia/client-common" "4.9.1"
+    "@algolia/client-search" "4.9.1"
+    "@algolia/transporter" "4.9.1"
 
 "@algolia/client-analytics@4.8.6":
   version "4.8.6"
@@ -130,15 +130,15 @@
     "@algolia/requester-common" "4.8.6"
     "@algolia/transporter" "4.8.6"
 
-"@algolia/client-analytics@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@algolia/client-analytics/-/client-analytics-4.9.0.tgz#4d559ffc9c644684fa152500178eafa1df21ba3d"
-  integrity sha512-5TafTR/uP9X4EpDOvBK1w4cgc3JpKeokPJqD37q46AH1IGI8UO5Gy1H5LxcGmPTIMdMnuSfiYgRJsyoEO1Co0A==
+"@algolia/client-analytics@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@algolia/client-analytics/-/client-analytics-4.9.1.tgz#56972496526910c53c5ce7844f4571efba63eb5f"
+  integrity sha512-/g6OkOSIA+A0t/tjvbL6iG/zV4El4LPFgv/tcAYHTH27BmlNtnEXw+iFpGjeUlQoPily9WVB3QNLMJkaNwL3HA==
   dependencies:
-    "@algolia/client-common" "4.9.0"
-    "@algolia/client-search" "4.9.0"
-    "@algolia/requester-common" "4.9.0"
-    "@algolia/transporter" "4.9.0"
+    "@algolia/client-common" "4.9.1"
+    "@algolia/client-search" "4.9.1"
+    "@algolia/requester-common" "4.9.1"
+    "@algolia/transporter" "4.9.1"
 
 "@algolia/client-common@4.8.6":
   version "4.8.6"
@@ -148,13 +148,13 @@
     "@algolia/requester-common" "4.8.6"
     "@algolia/transporter" "4.8.6"
 
-"@algolia/client-common@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@algolia/client-common/-/client-common-4.9.0.tgz#51f9cf66b99e4042647d344bb4dd1cd970de0f81"
-  integrity sha512-Rjk4XMXi6B63jdKQwnGbKwIubB5QIgok+k67QwrgadbqVphHueJ3af3D6i3sRcKBBTmdprFAXn0zX/zaxYBhAQ==
+"@algolia/client-common@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@algolia/client-common/-/client-common-4.9.1.tgz#ae313b65d3249efcb4fafd2e92ed1fa2fd075482"
+  integrity sha512-UziRTZ8km3qwoVPIyEre8TV6V+MX7UtbfVqPmSafZ0xu41UUZ+sL56YoKjOXkbKuybeIC9prXMGy/ID5bXkTqg==
   dependencies:
-    "@algolia/requester-common" "4.9.0"
-    "@algolia/transporter" "4.9.0"
+    "@algolia/requester-common" "4.9.1"
+    "@algolia/transporter" "4.9.1"
 
 "@algolia/client-recommendation@4.8.6":
   version "4.8.6"
@@ -165,14 +165,14 @@
     "@algolia/requester-common" "4.8.6"
     "@algolia/transporter" "4.8.6"
 
-"@algolia/client-recommendation@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@algolia/client-recommendation/-/client-recommendation-4.9.0.tgz#24992ff450d82fa982f8a3c9af7b043532cfa64b"
-  integrity sha512-6y6uyQmmowuBqMkk4iLeBOkd1qtBpfGJ5/di0S041eHQlD0v9WxyhbZyOopn0XxopSLbQaO22u0rjEcla7KYlA==
+"@algolia/client-recommendation@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@algolia/client-recommendation/-/client-recommendation-4.9.1.tgz#217af2a38d37ab12cf23a419cc9a576af9d15b13"
+  integrity sha512-Drtvvm1PNIOpYf4HFlkPFstFQ3IsN+TRmxur2F7y6Faplb5ybISa8ithu1tmlTdyTf3A78hQUQjgJet6qD2XZw==
   dependencies:
-    "@algolia/client-common" "4.9.0"
-    "@algolia/requester-common" "4.9.0"
-    "@algolia/transporter" "4.9.0"
+    "@algolia/client-common" "4.9.1"
+    "@algolia/requester-common" "4.9.1"
+    "@algolia/transporter" "4.9.1"
 
 "@algolia/client-search@4.8.6":
   version "4.8.6"
@@ -183,24 +183,24 @@
     "@algolia/requester-common" "4.8.6"
     "@algolia/transporter" "4.8.6"
 
-"@algolia/client-search@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@algolia/client-search/-/client-search-4.9.0.tgz#806379940d08cb95f562d93e31c2f0478fc040a4"
-  integrity sha512-HFfeUJN6GPHsjfcchmksoqlBLF5gT+jRHmSait4fWtde85eGFyJVL7ubUZD9KjlEjzebmUPPIZ1ixcupaTUBnw==
+"@algolia/client-search@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@algolia/client-search/-/client-search-4.9.1.tgz#a2fbc47a1b343dade9a8b06310231d51ff675b1b"
+  integrity sha512-r9Cw2r8kJr45iYncFDht6EshARghU265wuY8Q8oHrpFHjAziEYdsUOdNmQKbsSH5J3gLjDPx1EI5DzVd6ivn3w==
   dependencies:
-    "@algolia/client-common" "4.9.0"
-    "@algolia/requester-common" "4.9.0"
-    "@algolia/transporter" "4.9.0"
+    "@algolia/client-common" "4.9.1"
+    "@algolia/requester-common" "4.9.1"
+    "@algolia/transporter" "4.9.1"
 
 "@algolia/logger-common@4.8.6":
   version "4.8.6"
   resolved "https://registry.yarnpkg.com/@algolia/logger-common/-/logger-common-4.8.6.tgz#8c44a4f550e12418b0ec8d76a068e4f1c64206d1"
   integrity sha512-FMRxZGdDxSzd0/Mv0R1021FvUt0CcbsQLYeyckvSWX8w+Uk4o0lcV6UtZdERVR5XZsGOqoXLMIYDbR2vkbGbVw==
 
-"@algolia/logger-common@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@algolia/logger-common/-/logger-common-4.9.0.tgz#488f23c0758ab0cd79f0fcbbd3691fb216a0b0dc"
-  integrity sha512-OU8lzR1I8R0Qsgk+u4GOSFpEEKZkzPYZP1OXsw92gejW08k5N6kVLzfvVvgNA1KAeZPFXADdH26VBQ/2M9wF3g==
+"@algolia/logger-common@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@algolia/logger-common/-/logger-common-4.9.1.tgz#3323834095f2916338d2535d2df91c4723ac19f2"
+  integrity sha512-9mPrbFlFyPT7or/7PXTiJjyOewWB9QRkZKVXkt5zHAUiUzGxmmdpJIGpPv3YQnDur8lXrXaRI0MHXUuIDMY1ng==
 
 "@algolia/logger-console@4.8.6":
   version "4.8.6"
@@ -209,12 +209,12 @@
   dependencies:
     "@algolia/logger-common" "4.8.6"
 
-"@algolia/logger-console@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@algolia/logger-console/-/logger-console-4.9.0.tgz#fe6bdd316f163908617874fae9f61e3249ae23a2"
-  integrity sha512-CrBU+E2iA4xXnb1rwX3G1ox9O+N+OjxnWccL75sWr1nQ/kh08TPpV7TYAvQEOFEDj8vV1kPeYEMENulbjmVZSA==
+"@algolia/logger-console@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@algolia/logger-console/-/logger-console-4.9.1.tgz#c324ef26843dbed06b44586309331dbb949744ad"
+  integrity sha512-74VUwjtFjFpjZpi3QoHIPv0kcr3vWUSHX/Vs8PJW3lPsD4CgyhFenQbG9v+ZnyH0JrJwiYTtzfmrVh7IMWZGrQ==
   dependencies:
-    "@algolia/logger-common" "4.9.0"
+    "@algolia/logger-common" "4.9.1"
 
 "@algolia/requester-browser-xhr@4.8.6":
   version "4.8.6"
@@ -223,22 +223,22 @@
   dependencies:
     "@algolia/requester-common" "4.8.6"
 
-"@algolia/requester-browser-xhr@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.9.0.tgz#ae4f39171f74ea3532f66cd39be777eaafe8147d"
-  integrity sha512-KJESXTv4z+mDCn1C9b/azUqPTgIFVL/Y4+Eopz6YBg9Lj0C6KQrsW68w0uLJcGSw9o/qBoKcpUo4QNm4/CwrdQ==
+"@algolia/requester-browser-xhr@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.9.1.tgz#0812f3c7c4105a4646c0fba8429b172b2d0e01c5"
+  integrity sha512-zc46tk5o0ikOAz3uYiRAMxC2iVKAMFKT7nNZnLB5IzT0uqAh7pz/+D/UvIxP4bKmsllpBSnPcpfQF+OI4Ag/BA==
   dependencies:
-    "@algolia/requester-common" "4.9.0"
+    "@algolia/requester-common" "4.9.1"
 
 "@algolia/requester-common@4.8.6":
   version "4.8.6"
   resolved "https://registry.yarnpkg.com/@algolia/requester-common/-/requester-common-4.8.6.tgz#37ea1f9ecc1afcd91532b9f9c952c62fdef42bca"
   integrity sha512-r5xJqq/D9KACkI5DgRbrysVL5DUUagikpciH0k0zjBbm+cXiYfpmdflo/h6JnY6kmvWgjr/4DoeTjKYb/0deAQ==
 
-"@algolia/requester-common@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@algolia/requester-common/-/requester-common-4.9.0.tgz#e65d6fb08d239d86a0076ad32638fe2d8abedaf6"
-  integrity sha512-8/ljy4/pnB8d4/yTaJQa2t3oKdbsVq9nDXkwhCACVum8tGYSSGpCtpBGln6M4g+QdfBSQxYILTB1wwHLFUstmg==
+"@algolia/requester-common@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-common/-/requester-common-4.9.1.tgz#50fcf4c7c1ed7ae13159167ac1da2844d036a630"
+  integrity sha512-9hPgXnlCSbqJqF69M5x5WN3h51Dc+mk/iWNeJSVxExHGvCDfBBZd0v6S15i8q2a9cD1I2RnhMpbnX5BmGtabVA==
 
 "@algolia/requester-node-http@4.8.6":
   version "4.8.6"
@@ -247,12 +247,12 @@
   dependencies:
     "@algolia/requester-common" "4.8.6"
 
-"@algolia/requester-node-http@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@algolia/requester-node-http/-/requester-node-http-4.9.0.tgz#4cb7cf5b1f4228a3128ccb2700b790a6f81ec7e6"
-  integrity sha512-JpkjPXDCgT+Z8G8d/6hxId7+560HeCHoiDcEFr9eWR/kClAOgVwgVH1I64pmH8ucsjL7kdWbkxez7zBzPiV+Tg==
+"@algolia/requester-node-http@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-node-http/-/requester-node-http-4.9.1.tgz#70054a0aa5643072404fcb68042eec97c7abd1c8"
+  integrity sha512-vYNVbSCuyrCSCjHBQJk+tLZtWCjvvDf5tSbRJjyJYMqpnXuIuP7gZm24iHil4NPYBhbBj5NU2ZDAhc/gTn75Ag==
   dependencies:
-    "@algolia/requester-common" "4.9.0"
+    "@algolia/requester-common" "4.9.1"
 
 "@algolia/transporter@4.8.6":
   version "4.8.6"
@@ -263,14 +263,14 @@
     "@algolia/logger-common" "4.8.6"
     "@algolia/requester-common" "4.8.6"
 
-"@algolia/transporter@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@algolia/transporter/-/transporter-4.9.0.tgz#8d4cadcee1b848e3b7c3efbfb76f46c3a374afbb"
-  integrity sha512-GySLvXwg0DQ2LM0/W+hr9y1Co3QY1iNnhWA82gFhBrz7RWGzw47qEsh//9u/wnjl6S1WOjH+eKm5PaQATG1BXg==
+"@algolia/transporter@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@algolia/transporter/-/transporter-4.9.1.tgz#63ef3d9ae3b6556fa1ff1e6265bbab482bd084b7"
+  integrity sha512-AbjFfGzX+cAuj7Qyc536OxIQzjFOA5FU2ANGStx8LBH+AKXScwfkx67C05riuaRR5adSCLMSEbVvUscH0nF+6A==
   dependencies:
-    "@algolia/cache-common" "4.9.0"
-    "@algolia/logger-common" "4.9.0"
-    "@algolia/requester-common" "4.9.0"
+    "@algolia/cache-common" "4.9.1"
+    "@algolia/logger-common" "4.9.1"
+    "@algolia/requester-common" "4.9.1"
 
 "@babel/cli@7.12.8":
   version "7.12.8"
@@ -5272,25 +5272,25 @@ algoliasearch-helper@^3.3.4, algoliasearch-helper@^3.4.4:
   dependencies:
     events "^1.1.1"
 
-algoliasearch@4.9.0:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-4.9.0.tgz#76a78632014902845af5f1d7c02a7115e5b53b50"
-  integrity sha512-hhlza8j/uCWGe2kSz89HlcexiLxO1wzOKLNPWivNtZeZO5J85agbcMsrKV5+xLFI4LbulP/b/4/IvswxzPrGIw==
+algoliasearch@4.9.1:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-4.9.1.tgz#1fa8ece3f9808e465226176b88b953801c2274e0"
+  integrity sha512-EeJUYXzBEhZSsL6tXc3hseLBCtlNLa1MZ4mlMK6EeX38yRjY5vgnFcNNml6uUhlOjvheKxgkKRpPWkxgL8Cqkg==
   dependencies:
-    "@algolia/cache-browser-local-storage" "4.9.0"
-    "@algolia/cache-common" "4.9.0"
-    "@algolia/cache-in-memory" "4.9.0"
-    "@algolia/client-account" "4.9.0"
-    "@algolia/client-analytics" "4.9.0"
-    "@algolia/client-common" "4.9.0"
-    "@algolia/client-recommendation" "4.9.0"
-    "@algolia/client-search" "4.9.0"
-    "@algolia/logger-common" "4.9.0"
-    "@algolia/logger-console" "4.9.0"
-    "@algolia/requester-browser-xhr" "4.9.0"
-    "@algolia/requester-common" "4.9.0"
-    "@algolia/requester-node-http" "4.9.0"
-    "@algolia/transporter" "4.9.0"
+    "@algolia/cache-browser-local-storage" "4.9.1"
+    "@algolia/cache-common" "4.9.1"
+    "@algolia/cache-in-memory" "4.9.1"
+    "@algolia/client-account" "4.9.1"
+    "@algolia/client-analytics" "4.9.1"
+    "@algolia/client-common" "4.9.1"
+    "@algolia/client-recommendation" "4.9.1"
+    "@algolia/client-search" "4.9.1"
+    "@algolia/logger-common" "4.9.1"
+    "@algolia/logger-console" "4.9.1"
+    "@algolia/requester-browser-xhr" "4.9.1"
+    "@algolia/requester-common" "4.9.1"
+    "@algolia/requester-node-http" "4.9.1"
+    "@algolia/transporter" "4.9.1"
 
 algoliasearch@^4.0.0, algoliasearch@^4.8.4:
   version "4.8.6"


### PR DESCRIPTION
This updates the search client dependencies to 4.9.1 which bring better support for `facetQuery` typings.