### PR TITLE
feat(js): sync detached mode open state

### DIFF
--- a/packages/autocomplete-js/src/__tests__/detached.test.ts
+++ b/packages/autocomplete-js/src/__tests__/detached.test.ts
@@ -1,0 +1,98 @@
+import { fireEvent, waitFor } from '@testing-library/dom';
+
+import { autocomplete } from '../autocomplete';
+
+describe('detached', () => {
+  const originalMatchMedia = window.matchMedia;
+
+  beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn((query) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: originalMatchMedia,
+    });
+  });
+
+  test('closes after onSelect', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    autocomplete<{ label: string }>({
+      id: 'autocomplete',
+      detachedMediaQuery: '',
+      container,
+      getSources() {
+        return [
+          {
+            sourceId: 'testSource',
+            getItems() {
+              return [
+                { label: 'Item 1' },
+                { label: 'Item 2' },
+                { label: 'Item 3' },
+              ];
+            },
+            templates: {
+              item({ item }) {
+                return item.label;
+              },
+            },
+          },
+        ];
+      },
+    });
+
+    const searchButton = container.querySelector<HTMLButtonElement>(
+      '.aa-DetachedSearchButton'
+    );
+
+    // Open detached overlay
+    searchButton.click();
+
+    await waitFor(() => {
+      const input = document.querySelector<HTMLInputElement>('.aa-Input');
+
+      expect(document.querySelector('.aa-DetachedOverlay')).toBeInTheDocument();
+      expect(document.body).toHaveClass('aa-Detached');
+      expect(input).toHaveFocus();
+
+      fireEvent.input(input, { target: { value: 'a' } });
+    });
+
+    // Wait for the panel to open
+    await waitFor(() => {
+      expect(
+        document.querySelector<HTMLElement>('.aa-Panel')
+      ).toBeInTheDocument();
+    });
+
+    const firstItem = document.querySelector<HTMLLIElement>(
+      '#autocomplete-item-0'
+    );
+
+    // Select the first item
+    firstItem.click();
+
+    // The detached overlay should close
+    await waitFor(() => {
+      expect(
+        document.querySelector('.aa-DetachedOverlay')
+      ).not.toBeInTheDocument();
+      expect(document.body).not.toHaveClass('aa-Detached');
+    });
+  });
+});

--- a/packages/autocomplete-js/src/autocomplete.ts
+++ b/packages/autocomplete-js/src/autocomplete.ts
@@ -348,7 +348,6 @@ export function autocomplete<TItem extends BaseItem>(
         dom.value.input.focus();
       } else {
         document.body.removeChild(dom.value.detachedOverlay);
-
         document.body.classList.remove('aa-Detached');
         autocomplete.value.setQuery('');
         autocomplete.value.refresh();

--- a/packages/autocomplete-js/src/autocomplete.ts
+++ b/packages/autocomplete-js/src/autocomplete.ts
@@ -47,13 +47,6 @@ export function autocomplete<TItem extends BaseItem>(
     createAutocomplete<TItem>({
       ...props.value.core,
       onStateChange(params) {
-        if (
-          isDetached.value &&
-          params.prevState.isOpen !== params.state.isOpen
-        ) {
-          setIsModalOpen(params.state.isOpen);
-        }
-
         hasNoResultsSourceTemplateRef.current = params.state.collections.some(
           (collection) =>
             (collection.source as AutocompleteSource<TItem>).templates.noResults
@@ -229,6 +222,10 @@ export function autocomplete<TItem extends BaseItem>(
     }, 0);
 
     onStateChangeRef.current = ({ state, prevState }) => {
+      if (isDetached.value && prevState.isOpen !== state.isOpen) {
+        setIsModalOpen(state.isOpen);
+      }
+
       // The outer DOM might have changed since the last time the panel was
       // positioned. The layout might have shifted vertically for instance.
       // It's therefore safer to re-calculate the panel position before opening
@@ -338,22 +335,25 @@ export function autocomplete<TItem extends BaseItem>(
   }
 
   function setIsModalOpen(value: boolean) {
-    const prevValue = document.body.contains(dom.value.detachedOverlay);
+    requestAnimationFrame(() => {
+      const prevValue = document.body.contains(dom.value.detachedOverlay);
 
-    if (value === prevValue) {
-      return;
-    }
+      if (value === prevValue) {
+        return;
+      }
 
-    if (value) {
-      document.body.appendChild(dom.value.detachedOverlay);
-      document.body.classList.add('aa-Detached');
-      dom.value.input.focus();
-    } else {
-      document.body.removeChild(dom.value.detachedOverlay);
-      document.body.classList.remove('aa-Detached');
-      autocomplete.value.setQuery('');
-      autocomplete.value.refresh();
-    }
+      if (value) {
+        document.body.appendChild(dom.value.detachedOverlay);
+        document.body.classList.add('aa-Detached');
+        dom.value.input.focus();
+      } else {
+        document.body.removeChild(dom.value.detachedOverlay);
+
+        document.body.classList.remove('aa-Detached');
+        autocomplete.value.setQuery('');
+        autocomplete.value.refresh();
+      }
+    });
   }
 
   return {

--- a/packages/autocomplete-js/src/createAutocompleteDom.ts
+++ b/packages/autocomplete-js/src/createAutocompleteDom.ts
@@ -21,11 +21,8 @@ type CreateDomProps<TItem extends BaseItem> = {
   isDetached: boolean;
   placeholder?: string;
   propGetters: AutocompletePropGetters<TItem>;
+  setIsModalOpen(value: boolean): void;
   state: AutocompleteState<TItem>;
-};
-
-type CreateAutocompleteDomReturn = AutocompleteDom & {
-  openDetachedOverlay(): void;
 };
 
 export function createAutocompleteDom<TItem extends BaseItem>({
@@ -35,15 +32,9 @@ export function createAutocompleteDom<TItem extends BaseItem>({
   isDetached,
   placeholder = 'Search',
   propGetters,
+  setIsModalOpen,
   state,
-}: CreateDomProps<TItem>): CreateAutocompleteDomReturn {
-  function onDetachedOverlayClose() {
-    autocomplete.setQuery('');
-    autocomplete.setIsOpen(false);
-    autocomplete.refresh();
-    document.body.classList.remove('aa-Detached');
-  }
-
+}: CreateDomProps<TItem>): AutocompleteDom {
   const rootProps = propGetters.getRootProps({
     state,
     props: autocomplete.getRootProps({}),
@@ -63,8 +54,7 @@ export function createAutocompleteDom<TItem extends BaseItem>({
     class: classNames.detachedOverlay,
     children: [detachedContainer],
     onMouseDown() {
-      document.body.removeChild(detachedOverlay);
-      onDetachedOverlayClose();
+      setIsModalOpen(false);
     },
   });
 
@@ -103,8 +93,7 @@ export function createAutocompleteDom<TItem extends BaseItem>({
     autocompleteScopeApi,
     onDetachedEscape: isDetached
       ? () => {
-          document.body.removeChild(detachedOverlay);
-          onDetachedOverlayClose();
+          setIsModalOpen(false);
         }
       : undefined,
   });
@@ -148,12 +137,6 @@ export function createAutocompleteDom<TItem extends BaseItem>({
     });
   }
 
-  function openDetachedOverlay() {
-    document.body.appendChild(detachedOverlay);
-    document.body.classList.add('aa-Detached');
-    input.focus();
-  }
-
   if (isDetached) {
     const detachedSearchButtonIcon = createDomElement('div', {
       class: classNames.detachedSearchButtonIcon,
@@ -167,7 +150,7 @@ export function createAutocompleteDom<TItem extends BaseItem>({
       class: classNames.detachedSearchButton,
       onClick(event: MouseEvent) {
         event.preventDefault();
-        openDetachedOverlay();
+        setIsModalOpen(true);
       },
       children: [detachedSearchButtonIcon, detachedSearchButtonPlaceholder],
     });
@@ -175,8 +158,7 @@ export function createAutocompleteDom<TItem extends BaseItem>({
       class: classNames.detachedCancelButton,
       textContent: 'Cancel',
       onClick() {
-        document.body.removeChild(detachedOverlay);
-        onDetachedOverlayClose();
+        setIsModalOpen(false);
       },
     });
     const detachedFormContainer = createDomElement('div', {
@@ -191,7 +173,6 @@ export function createAutocompleteDom<TItem extends BaseItem>({
   }
 
   return {
-    openDetachedOverlay,
     detachedContainer,
     detachedOverlay,
     inputWrapper,

--- a/packages/autocomplete-js/src/createAutocompleteDom.ts
+++ b/packages/autocomplete-js/src/createAutocompleteDom.ts
@@ -55,6 +55,7 @@ export function createAutocompleteDom<TItem extends BaseItem>({
     children: [detachedContainer],
     onMouseDown() {
       setIsModalOpen(false);
+      autocomplete.setIsOpen(false);
     },
   });
 
@@ -93,6 +94,7 @@ export function createAutocompleteDom<TItem extends BaseItem>({
     autocompleteScopeApi,
     onDetachedEscape: isDetached
       ? () => {
+          autocomplete.setIsOpen(false);
           setIsModalOpen(false);
         }
       : undefined,
@@ -158,6 +160,7 @@ export function createAutocompleteDom<TItem extends BaseItem>({
       class: classNames.detachedCancelButton,
       textContent: 'Cancel',
       onClick() {
+        autocomplete.setIsOpen(false);
         setIsModalOpen(false);
       },
     });

--- a/packages/autocomplete-js/src/elements/Input.ts
+++ b/packages/autocomplete-js/src/elements/Input.ts
@@ -37,6 +37,7 @@ export const Input: AutocompleteElement<InputProps, HTMLInputElement> = ({
     ...inputProps,
     onKeyDown(event: KeyboardEvent) {
       if (onDetachedEscape && event.key === 'Escape') {
+        event.preventDefault();
         onDetachedEscape();
         return;
       }


### PR DESCRIPTION
## Description

This synchronizes the internal open state with the detached overlay open state.

It was a missing behavior that caused some trouble to users, unable to trigger an action (other than a link) after a selection on detached mode.

## Changes

We're now syncing the detached open state with the internal `isOpen` state. This means that `shouldPanelOpen` always return `true` on detached mode now. Otherwise, the detached overlay wouldn't be able to stay open under user conditions.

## Related

- Closes #547