### PR TITLE
docs(ts): update TSDoc links to official documentation

### DIFF
--- a/packages/autocomplete-core/src/types/AutocompleteOptions.ts
+++ b/packages/autocomplete-core/src/types/AutocompleteOptions.ts
@@ -51,10 +51,10 @@ export interface AutocompleteOptions<TItem extends BaseItem> {
    *
    * This is useful while developing because it keeps the panel open even when the blur event occurs. **Make sure to disable it in production.**
    *
-   * See [**Debugging**](https://autocomplete.algolia.com/docs/debugging) for more information.
+   * See [**Debugging**](https://www.algolia.com/doc/ui-libraries/autocomplete/guides/debugging/) for more information.
    *
    * @default false
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#debug
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-debug
    */
   debug?: boolean;
   /**
@@ -63,26 +63,26 @@ export interface AutocompleteOptions<TItem extends BaseItem> {
    * It is incremented by default when creating a new Autocomplete instance.
    *
    * @default "autocomplete-0"
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#id
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-id
    */
   id?: string;
   /**
    * The function called when the internal state changes.
    *
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#onstatechange
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-onstatechange
    */
   onStateChange?(props: OnStateChangeProps<TItem>): void;
   /**
    * The placeholder text to show in the search input when there's no query.
    *
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#placeholder
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-placeholder
    */
   placeholder?: string;
   /**
    * Whether to focus the search input or not when the page is loaded.
    *
    * @default false
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#autofocus
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-autofocus
    */
   autoFocus?: boolean;
   /**
@@ -91,33 +91,33 @@ export interface AutocompleteOptions<TItem extends BaseItem> {
    * We recommend using `0` when the autocomplete is used to open links, instead of triggering a search in an application.
    *
    * @default null
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#defaultactiveitemid
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-defaultactiveitemid
    */
   defaultActiveItemId?: number | null;
   /**
    * Whether to open the panel on focus when there's no query.
    *
    * @default false
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#openonfocus
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-openonfocus
    */
   openOnFocus?: boolean;
   /**
-   * How many milliseconds must elapse before considering the autocomplete experience [stalled](https://autocomplete.algolia.com/docs/state#status).
+   * How many milliseconds must elapse before considering the autocomplete experience [stalled](https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/state/#param-status).
    *
    * @default 300
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#stallthreshold
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-stallthreshold
    */
   stallThreshold?: number;
   /**
    * The initial state to apply when autocomplete is created.
    *
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#initialstate
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-initialstate
    */
   initialState?: Partial<AutocompleteState<TItem>>;
   /**
-   * The [sources](https://autocomplete.algolia.com/docs/sources) to get the suggestions from.
+   * The [sources](https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/sources/) to get the suggestions from.
    *
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#getsources
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-getsources
    */
   getSources?: GetSources<TItem>;
   /**
@@ -126,15 +126,15 @@ export interface AutocompleteOptions<TItem extends BaseItem> {
    * This is useful if you're using autocomplete in a different context than `window`.
    *
    * @default window
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#environment
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-environment
    */
   environment?: AutocompleteEnvironment;
   /**
    * An implementation of Autocomplete's Navigator API to redirect the user when opening a link.
    *
-   * Learn more on the [**Navigator API**](https://autocomplete.algolia.com/docs/keyboard-navigation) documentation.
+   * Learn more on the [**Navigator API**](https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/keyboard-navigation/) documentation.
    *
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#navigator
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-navigator
    */
   navigator?: Partial<AutocompleteNavigator<TItem>>;
   /**
@@ -142,27 +142,27 @@ export interface AutocompleteOptions<TItem extends BaseItem> {
    *
    * By default, the panel opens when there are items in the state.
    *
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#shouldpanelopen
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-shouldpanelopen
    */
   shouldPanelOpen?(params: { state: AutocompleteState<TItem> }): boolean;
   /**
    * The function called when submitting the Autocomplete form.
    *
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#onsubmit
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-onsubmit
    */
   onSubmit?(params: OnSubmitParams<TItem>): void;
   /**
    * The function called when resetting the Autocomplete form.
    *
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#onreset
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-onreset
    */
   onReset?(params: OnResetParams<TItem>): void;
   /**
    * The plugins that encapsulate and distribute custom Autocomplete behaviors.
    *
-   * See [**Plugins**](https://autocomplete.algolia.com/docs/plugins) for more information.
+   * See [**Plugins**](https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/plugins/) for more information.
    *
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#plugins
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-plugins
    */
   plugins?: Array<AutocompletePlugin<any, any>>;
 }

--- a/packages/autocomplete-core/src/types/AutocompletePlugin.ts
+++ b/packages/autocomplete-core/src/types/AutocompletePlugin.ts
@@ -21,10 +21,14 @@ export type AutocompletePlugin<
    * The function called when Autocomplete starts.
    *
    * It lets you subscribe to lifecycle hooks and interact with the instance's state and context.
+   *
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/plugins/#param-subscribe
    */
   subscribe?(params: PluginSubscribeParams<any>): void;
   /**
    * An extra plugin object to expose properties and functions as APIs.
+   *
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/plugins/#param-data
    */
   data?: TData;
 };

--- a/packages/autocomplete-core/src/types/AutocompleteSetters.ts
+++ b/packages/autocomplete-core/src/types/AutocompleteSetters.ts
@@ -13,19 +13,19 @@ export interface AutocompleteSetters<TItem extends BaseItem> {
    *
    * Pass `null` to unselect items.
    *
-   * @link https://autocomplete.algolia.com/docs/state#setactiveitemid
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/state/#param-setactiveitemid
    */
   setActiveItemId: StateUpdater<AutocompleteState<TItem>['activeItemId']>;
   /**
    * Sets the query.
    *
-   * @link https://autocomplete.algolia.com/docs/state#setquery
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/state/#param-setquery
    */
   setQuery: StateUpdater<AutocompleteState<TItem>['query']>;
   /**
    * Sets the collections.
    *
-   * @link https://autocomplete.algolia.com/docs/state#setcollections
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/state/#param-setcollections
    */
   setCollections: StateUpdater<
     Array<
@@ -35,21 +35,21 @@ export interface AutocompleteSetters<TItem extends BaseItem> {
   /**
    * Sets whether the panel is open or not.
    *
-   * @link https://autocomplete.algolia.com/docs/state#setisopen
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/state/#param-setisopen
    */
   setIsOpen: StateUpdater<AutocompleteState<TItem>['isOpen']>;
   /**
    * Sets the status of the autocomplete.
    *
-   * @link https://autocomplete.algolia.com/docs/state#setisopen
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/state/#param-setisopen
    */
   setStatus: StateUpdater<AutocompleteState<TItem>['status']>;
   /**
    * Sets the context passed to lifecycle hooks.
    *
-   * See more in [**Context**](https://autocomplete.algolia.com/docs/context).
+   * See more in [**Context**](https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/context/).
    *
-   * @link https://autocomplete.algolia.com/docs/state#setcontext
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/state/#param-setcontext
    */
   setContext: StateUpdater<AutocompleteState<TItem>['context']>;
 }

--- a/packages/autocomplete-core/src/types/AutocompleteSource.ts
+++ b/packages/autocomplete-core/src/types/AutocompleteSource.ts
@@ -39,7 +39,7 @@ export interface AutocompleteSource<TItem extends BaseItem> {
   /**
    * The function called to get the URL of the item.
    *
-   * The value is used to add [keyboard accessibility](https://autocomplete.algolia.com/docs/keyboard-navigation) features to let users open items in the current tab, a new tab, or a new window.
+   * The value is used to add [keyboard accessibility](https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/keyboard-navigation/) features to let users open items in the current tab, a new tab, or a new window.
    */
   getItemUrl?({
     item,

--- a/packages/autocomplete-js/src/types/AutocompleteOptions.ts
+++ b/packages/autocomplete-js/src/types/AutocompleteOptions.ts
@@ -39,7 +39,7 @@ export interface AutocompleteOptions<TItem extends BaseItem>
    *
    * You can either pass a [CSS selector](https://developer.mozilla.org/docs/Web/CSS/CSS_Selectors) or an [Element](https://developer.mozilla.org/docs/Web/API/HTMLElement). If there are several containers matching the selector, Autocomplete picks up the first one.
    *
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#container
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-container
    */
   container: string | HTMLElement;
   /**
@@ -48,14 +48,14 @@ export interface AutocompleteOptions<TItem extends BaseItem>
    * You can either pass a [CSS selector](https://developer.mozilla.org/docs/Web/CSS/CSS_Selectors) or an [Element](https://developer.mozilla.org/docs/Web/API/HTMLElement). If there are several containers matching the selector, Autocomplete picks up the first one.
    *
    * @default document.body
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#panelcontainer
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-panelcontainer
    */
   panelContainer?: string | HTMLElement;
   /**
    * The Media Query to turn Autocomplete into a detached experience.
    *
    * @default "(max-width: 680px)"
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#detachedmediaquery
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-detachedmediaquery
    * @link https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries
    */
   detachedMediaQuery?: string;
@@ -64,7 +64,7 @@ export interface AutocompleteOptions<TItem extends BaseItem>
    * The panel's horizontal position.
    *
    * @default "input-wrapper-width"
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#panelplacement
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-panelplacement
    */
   panelPlacement?: 'start' | 'end' | 'full-width' | 'input-wrapper-width';
   /**
@@ -72,7 +72,7 @@ export interface AutocompleteOptions<TItem extends BaseItem>
    *
    * This is useful to style your autocomplete with external CSS frameworks.
    *
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#classnames
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-classnames
    */
   classNames?: Partial<AutocompleteClassNames>;
   /**
@@ -80,7 +80,7 @@ export interface AutocompleteOptions<TItem extends BaseItem>
    *
    * This is useful to customize the rendering, for example, using multi-row or multi-column layouts.
    *
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#render
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-render
    */
   render?: AutocompleteRender<TItem>;
   /**
@@ -88,7 +88,7 @@ export interface AutocompleteOptions<TItem extends BaseItem>
    *
    * This is useful to let the user know that the query returned no results.
    *
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#rendernoresults
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-rendernoresults
    */
   renderNoResults?: AutocompleteRender<TItem>;
   initialState?: Partial<AutocompleteState<TItem>>;
@@ -96,16 +96,16 @@ export interface AutocompleteOptions<TItem extends BaseItem>
   /**
    * The virtual DOM implementation to plug to Autocomplete. It defaults to Preact.
    *
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#renderer
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-renderer
    */
   renderer?: AutocompleteRenderer;
   plugins?: Array<AutocompletePlugin<any, any>>;
   /**
    * Components to register in the Autocomplete rendering lifecycles.
    *
-   * Registered components become available in [`templates`](https://autocomplete.algolia.com/docs/autocomplete-jstemplates), [`render`](https://autocomplete.algolia.com/docs/autocomplete-js#render), and in [`renderNoResults`](https://autocomplete.algolia.com/docs/autocomplete-js#rendernoresults).
+   * Registered components become available in [`templates`](https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/templates/), [`render`](https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-render), and in [`renderNoResults`](https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-rendernoresults).
    *
-   * @link https://autocomplete.algolia.com/docs/autocomplete-js#components
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-components
    */
   components?: PublicAutocompleteComponents;
 }

--- a/packages/autocomplete-js/src/types/AutocompletePlugin.ts
+++ b/packages/autocomplete-js/src/types/AutocompletePlugin.ts
@@ -10,9 +10,11 @@ export type AutocompletePlugin<TItem extends BaseItem, TData> = Omit<
   'getSources'
 > & {
   /**
-   * The function called when the internal state changes.
+   * The [sources](https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/sources/) to get the suggestions from.
    *
-   * @link https://autocomplete.algolia.com/docs/plugins#onstatechange
+   * When defined, they’re merged with the sources of your Autocomplete instance.
+   *
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/plugins/#param-getsources
    */
   getSources?: AutocompleteOptions<TItem>['getSources'];
 };

--- a/packages/autocomplete-js/src/types/AutocompleteSource.ts
+++ b/packages/autocomplete-js/src/types/AutocompleteSource.ts
@@ -24,7 +24,7 @@ export type SourceTemplates<TItem extends BaseItem> = {
   /**
    * A function that returns the template for each item of the source.
    *
-   * @link https://autocomplete.algolia.com/docs/templates/#item
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/templates/#param-item
    */
   item: Template<{
     item: TItem;
@@ -33,7 +33,7 @@ export type SourceTemplates<TItem extends BaseItem> = {
   /**
    * A function that returns the template for the header (before the list of items).
    *
-   * @link https://autocomplete.algolia.com/docs/templates/#header
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/templates/#param-header
    */
   header?: Template<{
     state: AutocompleteState<TItem>;
@@ -43,7 +43,7 @@ export type SourceTemplates<TItem extends BaseItem> = {
   /**
    * A function that returns the template for the footer (after the list of items).
    *
-   * @link https://autocomplete.algolia.com/docs/templates/#footer
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/templates/#param-footer
    */
   footer?: Template<{
     state: AutocompleteState<TItem>;
@@ -53,7 +53,7 @@ export type SourceTemplates<TItem extends BaseItem> = {
   /**
    * A function that returns the template for when there are no items.
    *
-   * @link https://autocomplete.algolia.com/docs/templates/#noresults
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/templates/#param-noresults
    */
   noResults?: Template<{
     state: AutocompleteState<TItem>;
@@ -67,7 +67,7 @@ type WithTemplates<TType, TItem extends BaseItem> = TType & {
    *
    * See [**Displaying items with Templates**](templates) for more information.
    *
-   * @link https://autocomplete.algolia.com/docs/sources/#templates
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/sources/#param-templates
    */
   templates: SourceTemplates<TItem>;
 };

--- a/packages/autocomplete-js/src/types/AutocompleteState.ts
+++ b/packages/autocomplete-js/src/types/AutocompleteState.ts
@@ -12,7 +12,7 @@ export type AutocompleteState<TItem extends BaseItem> = Omit<
   /**
    * The collections of items.
    *
-   * @link https://autocomplete.algolia.com/docs/state/#collections
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/state/#param-collections
    */
   collections: Array<AutocompleteCollection<TItem>>;
 };

--- a/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
+++ b/packages/autocomplete-plugin-algolia-insights/src/createAlgoliaInsightsPlugin.ts
@@ -44,7 +44,7 @@ export type CreateAlgoliaInsightsPluginParams = {
   /**
    * The initialized Search Insights client.
    *
-   * @link https://autocomplete.algolia.com/docs/createAlgoliaInsightsPlugin#insightsclient
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-plugin-algolia-insights/createAlgoliaInsightsPlugin/#param-insightsclient
    */
   insightsClient: InsightsClient;
   /**
@@ -54,7 +54,7 @@ export type CreateAlgoliaInsightsPluginParams = {
    *
    * In as-you-type experiences, items change as the user types. This hook is debounced every 400ms to reflect actual items that users notice and avoid generating too many events for items matching "in progress" queries.
    *
-   * @link https://autocomplete.algolia.com/docs/createAlgoliaInsightsPlugin#onitemschange
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-plugin-algolia-insights/createAlgoliaInsightsPlugin/#param-onitemschange
    */
   onItemsChange?(params: OnItemsChangeParams): void;
   /**
@@ -62,7 +62,7 @@ export type CreateAlgoliaInsightsPluginParams = {
    *
    * By default, it sends a clickedObjectIDsAfterSearch event.
    *
-   * @link https://autocomplete.algolia.com/docs/createAlgoliaInsightsPlugin#onselect
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-plugin-algolia-insights/createAlgoliaInsightsPlugin/#param-onselect
    */
   onSelect?(params: OnSelectParams): void;
   /**
@@ -70,7 +70,7 @@ export type CreateAlgoliaInsightsPluginParams = {
    *
    * By default, it doesn't send any events.
    *
-   * @link https://autocomplete.algolia.com/docs/createAlgoliaInsightsPlugin#onactive
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-plugin-algolia-insights/createAlgoliaInsightsPlugin/#param-onactive
    */
   onActive?(params: OnActiveParams): void;
 };

--- a/packages/autocomplete-plugin-query-suggestions/src/createQuerySuggestionsPlugin.ts
+++ b/packages/autocomplete-plugin-query-suggestions/src/createQuerySuggestionsPlugin.ts
@@ -17,25 +17,25 @@ export type CreateQuerySuggestionsPluginParams<
   /**
    * The initialized Algolia search client.
    *
-   * @link https://autocomplete.algolia.com/docs/createQuerySuggestionsPlugin#searchclient
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-plugin-query-suggestions/createQuerySuggestionsPlugin/#param-searchclient
    */
   searchClient: SearchClient;
   /**
    * The index name.
    *
-   * @link https://autocomplete.algolia.com/docs/createQuerySuggestionsPlugin#indexname
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-plugin-query-suggestions/createQuerySuggestionsPlugin/#param-indexname
    */
   indexName: string;
   /**
    * A function returning [Algolia search parameters](https://www.algolia.com/doc/api-reference/search-api-parameters/).
    *
-   * @link https://autocomplete.algolia.com/docs/createQuerySuggestionsPlugin#getsearchparams
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-plugin-query-suggestions/createQuerySuggestionsPlugin/#param-getsearchparams
    */
   getSearchParams?(params: { state: AutocompleteState<TItem> }): SearchOptions;
   /**
    * A function to transform the provided source.
    *
-   * @link https://autocomplete.algolia.com/docs/createQuerySuggestionsPlugin#transformsource
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-plugin-query-suggestions/createQuerySuggestionsPlugin/#param-transformsource
    */
   transformSource?(params: {
     source: AutocompleteSource<TItem>;
@@ -47,21 +47,21 @@ export type CreateQuerySuggestionsPluginParams<
    *
    * @example ["instant_search", "facets", "exact_matches", "categories"]
    * @example ["instant_search", "facets", "exact_matches", "hierarchicalCategories.lvl0"]
-   * @link https://autocomplete.algolia.com/docs/createQuerySuggestionsPlugin#categoryattribute
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-plugin-query-suggestions/createQuerySuggestionsPlugin/#param-categoryattribute
    */
   categoryAttribute?: string | string[];
   /**
    * How many items to display categories for.
    *
    * @default 1
-   * @link https://autocomplete.algolia.com/docs/createQuerySuggestionsPlugin#itemswithcategories
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-plugin-query-suggestions/createQuerySuggestionsPlugin/#param-itemswithcategories
    */
   itemsWithCategories?: number;
   /**
    * The number of categories to display per item.
    *
    * @default 1
-   * @link https://autocomplete.algolia.com/docs/createQuerySuggestionsPlugin#categoriesperitem
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-plugin-query-suggestions/createQuerySuggestionsPlugin/#param-categoriesperitem
    */
   categoriesPerItem?: number;
 };

--- a/packages/autocomplete-plugin-recent-searches/src/createLocalStorageRecentSearchesPlugin.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/createLocalStorageRecentSearchesPlugin.ts
@@ -24,7 +24,7 @@ export type CreateRecentSearchesLocalStorageOptions<
    * The plugin namespaces all keys to avoid collisions.
    *
    * @example "top_searchbar"
-   * @link https://autocomplete.algolia.com/docs/createLocalStorageRecentSearchesPlugin#key
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-plugin-recent-searches/createLocalStorageRecentSearchesPlugin/#param-key
    */
   key: string;
 
@@ -32,16 +32,16 @@ export type CreateRecentSearchesLocalStorageOptions<
    * The number of recent searches to display.
    *
    * @default 5
-   * @link https://autocomplete.algolia.com/docs/createLocalStorageRecentSearchesPlugin#limit
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-plugin-recent-searches/createLocalStorageRecentSearchesPlugin/#param-limit
    */
   limit?: number;
 
   /**
    * A search function to retrieve recent searches from.
    *
-   * This function is called in [`storage.getAll`](https://autocomplete.algolia.com/docs/createRecentSearchesPlugin#storage) to retrieve recent searches and is useful to filter and highlight recent searches when typing a query.
+   * This function is called in [`storage.getAll`](https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-plugin-recent-searches/createRecentSearchesPlugin/#param-storage) to retrieve recent searches and is useful to filter and highlight recent searches when typing a query.
    *
-   * @link https://autocomplete.algolia.com/docs/createLocalStorageRecentSearchesPlugin#search
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-plugin-recent-searches/createLocalStorageRecentSearchesPlugin/#param-search
    */
   search?(params: SearchParams<TItem>): Array<Highlighted<TItem>>;
 };

--- a/packages/autocomplete-plugin-recent-searches/src/createRecentSearchesPlugin.ts
+++ b/packages/autocomplete-plugin-recent-searches/src/createRecentSearchesPlugin.ts
@@ -19,7 +19,7 @@ export interface RecentSearchesPluginData<TItem extends RecentSearchesItem>
    * This function enhances the provided search parameters by:
    * - Excluding Query Suggestions that are already displayed in recent searches.
    * - Using a shared `hitsPerPage` value to get a group limit of Query Suggestions and recent searches.
-   * @link https://autocomplete.algolia.com/docs/createLocalStorageRecentSearchesPlugin#getalgoliasearchparams
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-plugin-recent-searches/createLocalStorageRecentSearchesPlugin/#param-getalgoliasearchparams
    */
   getAlgoliaSearchParams(params?: SearchOptions): SearchOptions;
 }
@@ -30,13 +30,13 @@ export type CreateRecentSearchesPluginParams<
   /**
    * The storage to fetch from and save recent searches into.
    *
-   * @link https://autocomplete.algolia.com/docs/createRecentSearchesPlugin#storage
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-plugin-recent-searches/createRecentSearchesPlugin/#param-storage
    */
   storage: Storage<TItem>;
   /**
    * A function to transform the provided source.
    *
-   * @link https://autocomplete.algolia.com/docs/createRecentSearchesPlugin#transformsource
+   * @link https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-plugin-recent-searches/createRecentSearchesPlugin/#param-transformsource
    */
   transformSource?(params: {
     source: AutocompleteSource<TItem>;

--- a/packages/autocomplete-preset-algolia/src/requester/createRequester.ts
+++ b/packages/autocomplete-preset-algolia/src/requester/createRequester.ts
@@ -71,7 +71,7 @@ export type RequestParams<THit> = FetcherParams & {
   /**
    * The function to transform the Algolia response before passing it to the Autocomplete state. You have access to the full Algolia results, as well as the pre-computed hits and facet hits.
    *
-   * This is useful to manipulate the hits, or store data from the results in the [context](https://autocomplete.algolia.com/docs/context).
+   * This is useful to manipulate the hits, or store data from the results in the [context](https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/context/).
    */
   transformResponse?: TransformResponse<THit>;
 };


### PR DESCRIPTION
This updates all the documentation links from our TSDoc to the Algolia documentation website.

(Links won't work until we deploy the new documentation content.)