### PR TITLE
fix(core): support Insights in requesters

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "packages/autocomplete-core/dist/umd/index.production.js",
-      "maxSize": "5 kB"
+      "maxSize": "5.25 kB"
     },
     {
       "path": "packages/autocomplete-js/dist/umd/index.production.js",

--- a/packages/autocomplete-core/src/utils/__tests__/mapToAlgoliaResponse.test.ts
+++ b/packages/autocomplete-core/src/utils/__tests__/mapToAlgoliaResponse.test.ts
@@ -40,6 +40,138 @@ describe('mapToAlgoliaResponse', () => {
     expect(facetHits).toEqual([]);
   });
 
+  test('returns formatted results', () => {
+    const { results } = mapToAlgoliaResponse([
+      createSingleSearchResponse({
+        index: 'indexName',
+        queryID: 'queryID',
+        hits: [
+          {
+            objectID: '1',
+            label: 'Label 1',
+          },
+          {
+            objectID: '2',
+            label: 'Label 2',
+          },
+        ],
+      }),
+      createSingleSearchResponse({
+        index: 'indexName',
+        queryID: 'queryID',
+        hits: [
+          {
+            objectID: '3',
+            label: 'Label 3',
+          },
+          {
+            objectID: '4',
+            label: 'Label 4',
+          },
+        ],
+      }),
+    ]);
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        hits: [
+          {
+            __autocomplete_indexName: 'indexName',
+            __autocomplete_queryID: 'queryID',
+            label: 'Label 1',
+            objectID: '1',
+          },
+          {
+            __autocomplete_indexName: 'indexName',
+            __autocomplete_queryID: 'queryID',
+            label: 'Label 2',
+            objectID: '2',
+          },
+        ],
+      }),
+      expect.objectContaining({
+        hits: [
+          {
+            __autocomplete_indexName: 'indexName',
+            __autocomplete_queryID: 'queryID',
+            label: 'Label 3',
+            objectID: '3',
+          },
+          {
+            __autocomplete_indexName: 'indexName',
+            __autocomplete_queryID: 'queryID',
+            label: 'Label 4',
+            objectID: '4',
+          },
+        ],
+      }),
+    ]);
+  });
+
+  test('returns formatted hits', () => {
+    const { hits } = mapToAlgoliaResponse([
+      createSingleSearchResponse({
+        index: 'indexName',
+        queryID: 'queryID',
+        hits: [
+          {
+            objectID: '1',
+            label: 'Label 1',
+          },
+          {
+            objectID: '2',
+            label: 'Label 2',
+          },
+        ],
+      }),
+      createSingleSearchResponse({
+        index: 'indexName',
+        queryID: 'queryID',
+        hits: [
+          {
+            objectID: '3',
+            label: 'Label 3',
+          },
+          {
+            objectID: '4',
+            label: 'Label 4',
+          },
+        ],
+      }),
+    ]);
+
+    expect(hits).toEqual([
+      [
+        {
+          __autocomplete_indexName: 'indexName',
+          __autocomplete_queryID: 'queryID',
+          label: 'Label 1',
+          objectID: '1',
+        },
+        {
+          __autocomplete_indexName: 'indexName',
+          __autocomplete_queryID: 'queryID',
+          label: 'Label 2',
+          objectID: '2',
+        },
+      ],
+      [
+        {
+          __autocomplete_indexName: 'indexName',
+          __autocomplete_queryID: 'queryID',
+          label: 'Label 3',
+          objectID: '3',
+        },
+        {
+          __autocomplete_indexName: 'indexName',
+          __autocomplete_queryID: 'queryID',
+          label: 'Label 4',
+          objectID: '4',
+        },
+      ],
+    ]);
+  });
+
   test('returns formatted facet hits', () => {
     const { facetHits } = mapToAlgoliaResponse([
       createSFFVResponse({

--- a/packages/autocomplete-core/src/utils/mapToAlgoliaResponse.ts
+++ b/packages/autocomplete-core/src/utils/mapToAlgoliaResponse.ts
@@ -4,8 +4,24 @@ import type {
 } from '@algolia/client-search';
 
 export function mapToAlgoliaResponse<THit>(
-  results: Array<SearchResponse<THit> | SearchForFacetValuesResponse>
+  rawResults: Array<SearchResponse<THit> | SearchForFacetValuesResponse>
 ) {
+  const results: Array<
+    SearchResponse<THit> | SearchForFacetValuesResponse
+  > = rawResults.map((result) => {
+    return {
+      ...result,
+      hits: (result as SearchResponse<THit>).hits?.map((hit) => {
+        // Bring support for the Insights plugin.
+        return {
+          ...hit,
+          __autocomplete_indexName: (result as SearchResponse<THit>).index,
+          __autocomplete_queryID: (result as SearchResponse<THit>).queryID,
+        };
+      }),
+    };
+  });
+
   return {
     results,
     hits: results
@@ -14,6 +30,7 @@ export function mapToAlgoliaResponse<THit>(
     facetHits: results
       .map((result) =>
         (result as SearchForFacetValuesResponse).facetHits?.map((facetHit) => {
+          // Bring support for the highlighting components.
           return {
             label: facetHit.value,
             count: facetHit.count,


### PR DESCRIPTION
## Description

In #540, we introduced the Requester API to batch Algolia queries, but we [left out Insights plugin support](https://github.com/algolia/autocomplete/blob/c62f1d2757c5824c5a2f456c20cf55ca3d962cdb/packages/autocomplete-preset-algolia/src/search/getAlgoliaHits.ts#L18-L19). These metadata fields are required for the Insights plugin to send events to the API.

This PR brings support for the Insights plugin from requesters by adding back the necessary metadata in the hits returned by the Algolia API.

## Related

- https://github.com/algolia/autocomplete/discussions/559#discussioncomment-686775