### PR TITLE
chore(prettier): update config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
-node_modules
-dist
-build
-.docusaurus
 .cache
+.parcel-cache
+build
+coverage
+dist
+node_modules

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,5 @@
 {
   "proseWrap": "never",
   "singleQuote": true,
-  "trailingComma": "es5",
-  "endOfLine":"auto"
+  "trailingComma": "es5"
 }

--- a/examples/react-renderer/tsconfig.json
+++ b/examples/react-renderer/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,7 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
This sets Prettier's `endOfLine` configuration to its default which is set to `"lf"`.

It also updates the files that Prettier should ignore.

See: https://prettier.io/docs/en/options.html#end-of-line