### PR TITLE
chore(eslint): remove Docusaurus files from config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,6 @@
 .cache
-.docusaurus
+.parcel-cache
 build
 coverage
 dist
 node_modules
-.parcel-cache


### PR DESCRIPTION
The `.docusaurus` folder doesn't exist anymore so we don't need to ignore it in our ESLint config.