### PR TITLE
fix(js): render `noResults` template when `openOnFocus` is `true`

### DIFF
--- a/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
+++ b/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
@@ -278,7 +278,7 @@ describe('autocomplete-js', () => {
     });
   });
 
-  test("doesn't render noResults template on no query when openOnFocus is false", async () => {
+  test("doesn't render noResults template on empty query when openOnFocus is false", async () => {
     const container = document.createElement('div');
     const panelContainer = document.createElement('div');
 
@@ -309,7 +309,7 @@ describe('autocomplete-js', () => {
 
     const input = container.querySelector<HTMLInputElement>('.aa-Input');
 
-    fireEvent.input(input, { target: { value: '' } });
+    fireEvent.focus(input);
 
     await waitFor(() => {
       expect(
@@ -318,7 +318,47 @@ describe('autocomplete-js', () => {
     });
   });
 
-  test('render noResults template on query when openOnFocus is false', async () => {
+  test('renders noResults template on empty query when openOnFocus is true', async () => {
+    const container = document.createElement('div');
+    const panelContainer = document.createElement('div');
+
+    document.body.appendChild(panelContainer);
+    autocomplete<{ label: string }>({
+      container,
+      panelContainer,
+      openOnFocus: true,
+      getSources() {
+        return [
+          {
+            sourceId: 'testSource',
+            getItems() {
+              return [];
+            },
+            templates: {
+              item({ item }) {
+                return item.label;
+              },
+              noResults() {
+                return 'No results template';
+              },
+            },
+          },
+        ];
+      },
+    });
+
+    const input = container.querySelector<HTMLInputElement>('.aa-Input');
+
+    fireEvent.focus(input);
+
+    await waitFor(() => {
+      expect(
+        panelContainer.querySelector<HTMLElement>('.aa-Panel')
+      ).toHaveTextContent('No results template');
+    });
+  });
+
+  test('renders noResults template on query when openOnFocus is false', async () => {
     const container = document.createElement('div');
     const panelContainer = document.createElement('div');
 

--- a/packages/autocomplete-js/src/render.tsx
+++ b/packages/autocomplete-js/src/render.tsx
@@ -109,9 +109,7 @@ export function renderPanel<TItem extends BaseItem>(
         </div>
       )}
 
-      {!items.length &&
-      source.templates.noResults &&
-      (state.query || state.isOpen) ? (
+      {source.templates.noResults && items.length === 0 ? (
         <div className={classNames.sourceNoResults}>
           {source.templates.noResults({
             components,

--- a/packages/autocomplete-js/src/render.tsx
+++ b/packages/autocomplete-js/src/render.tsx
@@ -109,7 +109,9 @@ export function renderPanel<TItem extends BaseItem>(
         </div>
       )}
 
-      {items.length === 0 && source.templates.noResults && state.query ? (
+      {!items.length &&
+      source.templates.noResults &&
+      (state.query || state.isOpen) ? (
         <div className={classNames.sourceNoResults}>
           {source.templates.noResults({
             components,


### PR DESCRIPTION
**Summary**
On an empty query, nothing is rendered when `openOnFocus` is `true` and a `noResults` template is provided.

**[live reproduction](https://codesandbox.io/s/serene-shadow-26bhx?file=/app.tsx)**:
- Focus input: nothing is rendered.
- Type something: `noResults` template is rendered.

**Result**
The `noResults` template is rendered on an empty query with `openOnFocus: true`