### PR TITLE
docs(examples): use InstantSearch's `getUiState`

### DIFF
--- a/examples/instantsearch/package.json
+++ b/examples/instantsearch/package.json
@@ -15,7 +15,7 @@
     "@algolia/autocomplete-theme-classic": "1.0.0",
     "@algolia/client-search": "4.9.1",
     "algoliasearch": "4.9.1",
-    "instantsearch.js": "4.21.0",
+    "instantsearch.js": "4.22.0",
     "preact": "10.5.13"
   },
   "devDependencies": {

--- a/examples/instantsearch/src/instantsearch.ts
+++ b/examples/instantsearch/src/instantsearch.ts
@@ -167,17 +167,13 @@ export const debouncedSetInstantSearchUiState = debounce(
 
 // Get the current category from InstantSearch.
 export function getInstantSearchCurrentCategory() {
-  const indexRenderState = search.renderState[INSTANT_SEARCH_INDEX_NAME];
-  const hierarchicalMenuUiState =
-    indexRenderState && indexRenderState.hierarchicalMenu;
-  const categories =
-    (hierarchicalMenuUiState &&
-      hierarchicalMenuUiState[INSTANT_SEARCH_HIERARCHICAL_ATTRIBUTE] &&
-      hierarchicalMenuUiState[INSTANT_SEARCH_HIERARCHICAL_ATTRIBUTE].items) ||
-    [];
-  const refinedCategory = categories.find((category) => category.isRefined);
+  const indexUiState = search.getUiState()[INSTANT_SEARCH_INDEX_NAME];
+  const hierarchicalMenuUiState = indexUiState && indexUiState.hierarchicalMenu;
+  const currentCategories =
+    hierarchicalMenuUiState &&
+    hierarchicalMenuUiState[INSTANT_SEARCH_HIERARCHICAL_ATTRIBUTE];
 
-  return refinedCategory && refinedCategory.value;
+  return currentCategories && currentCategories[0];
 }
 
 // Build URLs that InstantSearch understands.

--- a/yarn.lock
+++ b/yarn.lock
@@ -10535,10 +10535,10 @@ inquirer@^7.0.0:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
-instantsearch.js@4.21.0:
-  version "4.21.0"
-  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.21.0.tgz#3eec6b596795af7ec534d510fef58f36236a87e5"
-  integrity sha512-SgA7wRyicP8Uwdomp0dNQY9rWIjRSuTfyPgQ6GjRuYT7k8pfC7scHpC9CSfsTi6d0FTV18Psk+citFDRhXlffg==
+instantsearch.js@4.22.0:
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.22.0.tgz#d28c7a2be6b399736f8f2edd6f59d474a0f661a4"
+  integrity sha512-IPjg/EwhDqFpvCJC1g3DF+i2cAr3SQZ9JPFhuKWC2apnGNfiFkPIQKvHx1pFTQm7FlZe262Xcpqi1ag1KVPGpA==
   dependencies:
     "@types/googlemaps" "^3.39.6"
     algoliasearch-helper "^3.4.4"


### PR DESCRIPTION
In algolia/instantsearch.js#4750 we introduced the `getUiState` API which allows to retrieve the current category more easily.