### PR TITLE
fix(js): support panel scroll top position in all browsers

### DIFF
--- a/packages/autocomplete-js/src/getPanelPlacementStyle.ts
+++ b/packages/autocomplete-js/src/getPanelPlacementStyle.ts
@@ -15,10 +15,14 @@ export function getPanelPlacementStyle({
   environment,
 }: GetPanelPlacementStyleParams) {
   const containerRect = container.getBoundingClientRect();
-  const top =
-    environment.document.body.scrollTop +
-    containerRect.top +
-    containerRect.height;
+  // Some browsers have specificities to retrieve the document scroll position.
+  // See https://stackoverflow.com/a/28633515/9940315
+  const scrollTop =
+    (environment.pageYOffset as number) ||
+    environment.document.documentElement.scrollTop ||
+    environment.document.body.scrollTop ||
+    0;
+  const top = scrollTop + containerRect.top + containerRect.height;
 
   switch (panelPlacement) {
     case 'start': {


### PR DESCRIPTION
## Description

Some browsers have specificities to retrieve the document scroll position. This solution should support all browsers.

## References

- https://github.com/algolia/autocomplete/issues/591#issuecomment-847972545
- https://stackoverflow.com/a/28633515/9940315