### PR TITLE
fix(core): open closed panel on `ArrowDown` and `ArrowUp`

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "packages/autocomplete-js/dist/umd/index.production.js",
-      "maxSize": "15.5 kB"
+      "maxSize": "15.75 kB"
     },
     {
       "path": "packages/autocomplete-preset-algolia/dist/umd/index.production.js",

--- a/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
@@ -787,29 +787,31 @@ describe('getInputProps', () => {
         expect(onActive).toHaveBeenCalledTimes(1);
       });
 
-      test('ArrowDown opens the panel when closed with openOnFocus', () => {
+      test('ArrowDown opens the panel when closed with openOnFocus and selects defaultActiveItemId', async () => {
         const onStateChange = jest.fn();
         const { inputElement } = createPlayground(createAutocomplete, {
           onStateChange,
           openOnFocus: true,
-          initialState: {
-            collections: [
-              createCollection({
-                items: [{ label: '1' }, { label: '2' }],
+          getSources() {
+            return [
+              createSource({
+                getItems() {
+                  return [{ label: '1' }, { label: '2' }];
+                },
               }),
-            ],
+            ];
           },
         });
 
         inputElement.focus();
-        userEvent.type(inputElement, '{esc}{arrowdown}');
+        await runAllMicroTasks();
 
-        waitFor(() => {
+        userEvent.type(inputElement, '{esc}{arrowdown}');
+        await runAllMicroTasks();
+
+        await waitFor(() => {
           expect(onStateChange).toHaveBeenLastCalledWith(
             expect.objectContaining({
-              prevState: expect.objectContaining({
-                isOpen: false,
-              }),
               state: expect.objectContaining({
                 isOpen: true,
                 activeItemId: null,
@@ -819,29 +821,33 @@ describe('getInputProps', () => {
         });
       });
 
-      test('ArrowDown opens the panel when closed with a query', () => {
+      test('ArrowDown opens the panel when closed with a query and selects defaultActiveItemId', async () => {
         const onStateChange = jest.fn();
         const { inputElement } = createPlayground(createAutocomplete, {
           onStateChange,
           initialState: {
             query: 'a',
-            collections: [
-              createCollection({
-                items: [{ label: '1' }, { label: '2' }],
+          },
+          getSources() {
+            return [
+              createSource({
+                getItems() {
+                  return [{ label: '1' }, { label: '2' }];
+                },
               }),
-            ],
+            ];
           },
         });
 
         inputElement.focus();
-        userEvent.type(inputElement, '{esc}{arrowdown}');
+        await runAllMicroTasks();
 
-        waitFor(() => {
+        userEvent.type(inputElement, '{esc}{arrowdown}');
+        await runAllMicroTasks();
+
+        await waitFor(() => {
           expect(onStateChange).toHaveBeenLastCalledWith(
             expect.objectContaining({
-              prevState: expect.objectContaining({
-                isOpen: false,
-              }),
               state: expect.objectContaining({
                 isOpen: true,
                 activeItemId: null,
@@ -851,29 +857,31 @@ describe('getInputProps', () => {
         });
       });
 
-      test('ArrowUp opens the panel when closed with openOnFocus', () => {
+      test('ArrowUp opens the panel when closed with openOnFocus and selects the last item', async () => {
         const onStateChange = jest.fn();
         const { inputElement } = createPlayground(createAutocomplete, {
           onStateChange,
           openOnFocus: true,
-          initialState: {
-            collections: [
-              createCollection({
-                items: [{ label: '1' }, { label: '2' }],
+          getSources() {
+            return [
+              createSource({
+                getItems() {
+                  return [{ label: '1' }, { label: '2' }];
+                },
               }),
-            ],
+            ];
           },
         });
 
         inputElement.focus();
-        userEvent.type(inputElement, '{esc}{arrowup}');
+        await runAllMicroTasks();
 
-        waitFor(() => {
+        userEvent.type(inputElement, '{esc}{arrowup}');
+        await runAllMicroTasks();
+
+        await waitFor(() => {
           expect(onStateChange).toHaveBeenLastCalledWith(
             expect.objectContaining({
-              prevState: expect.objectContaining({
-                isOpen: false,
-              }),
               state: expect.objectContaining({
                 isOpen: true,
                 activeItemId: 1,
@@ -883,29 +891,33 @@ describe('getInputProps', () => {
         });
       });
 
-      test('ArrowUp opens the panel when closed with a query', () => {
+      test('ArrowUp opens the panel when closed with a query and selects the last item', async () => {
         const onStateChange = jest.fn();
         const { inputElement } = createPlayground(createAutocomplete, {
           onStateChange,
           initialState: {
             query: 'a',
-            collections: [
-              createCollection({
-                items: [{ label: '1' }, { label: '2' }],
+          },
+          getSources() {
+            return [
+              createSource({
+                getItems() {
+                  return [{ label: '1' }, { label: '2' }];
+                },
               }),
-            ],
+            ];
           },
         });
 
         inputElement.focus();
-        userEvent.type(inputElement, '{esc}{arrowup}');
+        await runAllMicroTasks();
 
-        waitFor(() => {
+        userEvent.type(inputElement, '{esc}{arrowup}');
+        await runAllMicroTasks();
+
+        await waitFor(() => {
           expect(onStateChange).toHaveBeenLastCalledWith(
             expect.objectContaining({
-              prevState: expect.objectContaining({
-                isOpen: false,
-              }),
               state: expect.objectContaining({
                 isOpen: true,
                 activeItemId: 1,

--- a/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 
 import {
@@ -785,6 +786,134 @@ describe('getInputProps', () => {
         userEvent.type(inputElement, '{arrowup}');
         expect(onActive).toHaveBeenCalledTimes(1);
       });
+
+      test('ArrowDown opens the panel when closed with openOnFocus', () => {
+        const onStateChange = jest.fn();
+        const { inputElement } = createPlayground(createAutocomplete, {
+          onStateChange,
+          openOnFocus: true,
+          initialState: {
+            collections: [
+              createCollection({
+                items: [{ label: '1' }, { label: '2' }],
+              }),
+            ],
+          },
+        });
+
+        inputElement.focus();
+        userEvent.type(inputElement, '{esc}{arrowdown}');
+
+        waitFor(() => {
+          expect(onStateChange).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              prevState: expect.objectContaining({
+                isOpen: false,
+              }),
+              state: expect.objectContaining({
+                isOpen: true,
+                activeItemId: null,
+              }),
+            })
+          );
+        });
+      });
+
+      test('ArrowDown opens the panel when closed with a query', () => {
+        const onStateChange = jest.fn();
+        const { inputElement } = createPlayground(createAutocomplete, {
+          onStateChange,
+          initialState: {
+            query: 'a',
+            collections: [
+              createCollection({
+                items: [{ label: '1' }, { label: '2' }],
+              }),
+            ],
+          },
+        });
+
+        inputElement.focus();
+        userEvent.type(inputElement, '{esc}{arrowdown}');
+
+        waitFor(() => {
+          expect(onStateChange).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              prevState: expect.objectContaining({
+                isOpen: false,
+              }),
+              state: expect.objectContaining({
+                isOpen: true,
+                activeItemId: null,
+              }),
+            })
+          );
+        });
+      });
+
+      test('ArrowUp opens the panel when closed with openOnFocus', () => {
+        const onStateChange = jest.fn();
+        const { inputElement } = createPlayground(createAutocomplete, {
+          onStateChange,
+          openOnFocus: true,
+          initialState: {
+            collections: [
+              createCollection({
+                items: [{ label: '1' }, { label: '2' }],
+              }),
+            ],
+          },
+        });
+
+        inputElement.focus();
+        userEvent.type(inputElement, '{esc}{arrowup}');
+
+        waitFor(() => {
+          expect(onStateChange).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              prevState: expect.objectContaining({
+                isOpen: false,
+              }),
+              state: expect.objectContaining({
+                isOpen: true,
+                activeItemId: 1,
+              }),
+            })
+          );
+        });
+      });
+
+      test('ArrowUp opens the panel when closed with a query', () => {
+        const onStateChange = jest.fn();
+        const { inputElement } = createPlayground(createAutocomplete, {
+          onStateChange,
+          initialState: {
+            query: 'a',
+            collections: [
+              createCollection({
+                items: [{ label: '1' }, { label: '2' }],
+              }),
+            ],
+          },
+        });
+
+        inputElement.focus();
+        userEvent.type(inputElement, '{esc}{arrowup}');
+
+        waitFor(() => {
+          expect(onStateChange).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              prevState: expect.objectContaining({
+                isOpen: false,
+              }),
+              state: expect.objectContaining({
+                isOpen: true,
+                activeItemId: 1,
+              }),
+            })
+          );
+        });
+      });
     });
 
     describe('Escape', () => {
@@ -860,6 +989,7 @@ describe('getInputProps', () => {
             state: expect.objectContaining({
               query: '',
               status: 'idle',
+              activeItemId: null,
               collections: [],
             }),
           })

--- a/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
@@ -796,7 +796,7 @@ describe('getInputProps', () => {
             return [
               createSource({
                 getItems() {
-                  return [{ label: '1' }, { label: '2' }];
+                  return [{ label: '1' }];
                 },
               }),
             ];
@@ -832,7 +832,7 @@ describe('getInputProps', () => {
             return [
               createSource({
                 getItems() {
-                  return [{ label: '1' }, { label: '2' }];
+                  return [{ label: '1' }];
                 },
               }),
             ];
@@ -857,6 +857,44 @@ describe('getInputProps', () => {
         });
       });
 
+      test('ArrowDown opens the panel when closed with openOnFocus and selects defaultActiveItemId with scrollIntoView', async () => {
+        const onStateChange = jest.fn();
+        const { inputElement, item } = setupTestWithItem({
+          onStateChange,
+          defaultActiveItemId: 0,
+          getSources() {
+            return [
+              createSource({
+                getItems() {
+                  return [{ label: '1' }];
+                },
+              }),
+            ];
+          },
+        });
+        item.scrollIntoView = jest.fn();
+
+        inputElement.focus();
+        await runAllMicroTasks();
+
+        userEvent.type(inputElement, '{esc}{arrowdown}');
+        await runAllMicroTasks();
+
+        await waitFor(() => {
+          expect(onStateChange).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              state: expect.objectContaining({
+                isOpen: true,
+                activeItemId: 0,
+              }),
+            })
+          );
+
+          expect(item.scrollIntoView).toHaveBeenCalledTimes(1);
+          expect(item.scrollIntoView).toHaveBeenCalledWith(false);
+        });
+      });
+
       test('ArrowUp opens the panel when closed with openOnFocus and selects the last item', async () => {
         const onStateChange = jest.fn();
         const { inputElement } = createPlayground(createAutocomplete, {
@@ -866,7 +904,7 @@ describe('getInputProps', () => {
             return [
               createSource({
                 getItems() {
-                  return [{ label: '1' }, { label: '2' }];
+                  return [{ label: '1' }];
                 },
               }),
             ];
@@ -884,7 +922,7 @@ describe('getInputProps', () => {
             expect.objectContaining({
               state: expect.objectContaining({
                 isOpen: true,
-                activeItemId: 1,
+                activeItemId: 0,
               }),
             })
           );
@@ -902,7 +940,7 @@ describe('getInputProps', () => {
             return [
               createSource({
                 getItems() {
-                  return [{ label: '1' }, { label: '2' }];
+                  return [{ label: '1' }];
                 },
               }),
             ];
@@ -920,10 +958,47 @@ describe('getInputProps', () => {
             expect.objectContaining({
               state: expect.objectContaining({
                 isOpen: true,
-                activeItemId: 1,
+                activeItemId: 0,
               }),
             })
           );
+        });
+      });
+
+      test('ArrowUp opens the panel when closed with openOnFocus and selects the last item with scrollIntoView', async () => {
+        const onStateChange = jest.fn();
+        const { inputElement, item } = setupTestWithItem({
+          onStateChange,
+          getSources() {
+            return [
+              createSource({
+                getItems() {
+                  return [{ label: '1' }];
+                },
+              }),
+            ];
+          },
+        });
+        item.scrollIntoView = jest.fn();
+
+        inputElement.focus();
+        await runAllMicroTasks();
+
+        userEvent.type(inputElement, '{esc}{arrowup}');
+        await runAllMicroTasks();
+
+        await waitFor(() => {
+          expect(onStateChange).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              state: expect.objectContaining({
+                isOpen: true,
+                activeItemId: 0,
+              }),
+            })
+          );
+
+          expect(item.scrollIntoView).toHaveBeenCalledTimes(1);
+          expect(item.scrollIntoView).toHaveBeenCalledWith(false);
         });
       });
     });

--- a/packages/autocomplete-core/src/onKeyDown.ts
+++ b/packages/autocomplete-core/src/onKeyDown.ts
@@ -59,7 +59,7 @@ export function onKeyDown<TItem extends BaseItem>({
     }
 
     // Default browser behavior changes the caret placement on ArrowUp and
-    // Arrow down.
+    // ArrowDown.
     event.preventDefault();
 
     // When re-opening the panel, we need to split the logic to keep the actions
@@ -80,15 +80,17 @@ export function onKeyDown<TItem extends BaseItem>({
           nextActiveItemId: props.defaultActiveItemId,
         });
 
-        // We need to wait for the panel to open.
-        setTimeout(triggerScrollIntoView, 0);
         triggerOnActive();
+        // Since we rely on the DOM, we need to wait for all the micro tasks to
+        // finish (which include re-opening the panel) to make sure all the
+        // elements are available.
+        setTimeout(triggerScrollIntoView, 0);
       });
     } else {
       store.dispatch(event.key, {});
 
-      triggerScrollIntoView();
       triggerOnActive();
+      triggerScrollIntoView();
     }
   } else if (event.key === 'Escape') {
     // This prevents the default browser behavior on `input[type="search"]`

--- a/packages/autocomplete-core/src/onKeyDown.ts
+++ b/packages/autocomplete-core/src/onKeyDown.ts
@@ -1,5 +1,6 @@
 import { onInput } from './onInput';
 import {
+  ActionType,
   AutocompleteScopeApi,
   AutocompleteStore,
   BaseItem,
@@ -22,39 +23,72 @@ export function onKeyDown<TItem extends BaseItem>({
   ...setters
 }: OnKeyDownOptions<TItem>): void {
   if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+    // eslint-disable-next-line no-inner-declarations
+    function triggerScrollIntoView() {
+      const nodeItem = props.environment.document.getElementById(
+        `${props.id}-item-${store.getState().activeItemId}`
+      );
+
+      if (nodeItem) {
+        if ((nodeItem as any).scrollIntoViewIfNeeded) {
+          (nodeItem as any).scrollIntoViewIfNeeded(false);
+        } else {
+          nodeItem.scrollIntoView(false);
+        }
+      }
+    }
+
+    // eslint-disable-next-line no-inner-declarations
+    function triggerOnActive() {
+      const highlightedItem = getActiveItem(store.getState());
+
+      if (store.getState().activeItemId !== null && highlightedItem) {
+        const { item, itemInputValue, itemUrl, source } = highlightedItem;
+
+        source.onActive({
+          event,
+          item,
+          itemInputValue,
+          itemUrl,
+          refresh,
+          source,
+          state: store.getState(),
+          ...setters,
+        });
+      }
+    }
+
     // Default browser behavior changes the caret placement on ArrowUp and
     // Arrow down.
     event.preventDefault();
 
-    store.dispatch(event.key, null);
-
-    const nodeItem = props.environment.document.getElementById(
-      `${props.id}-item-${store.getState().activeItemId}`
-    );
-
-    if (nodeItem) {
-      if ((nodeItem as any).scrollIntoViewIfNeeded) {
-        (nodeItem as any).scrollIntoViewIfNeeded(false);
-      } else {
-        nodeItem.scrollIntoView(false);
-      }
-    }
-
-    const highlightedItem = getActiveItem(store.getState());
-
-    if (store.getState().activeItemId !== null && highlightedItem) {
-      const { item, itemInputValue, itemUrl, source } = highlightedItem;
-
-      source.onActive({
+    // When re-opening the panel, we need to split the logic to keep the actions
+    // synchronized as `onInput` returns a promise.
+    if (
+      store.getState().isOpen === false &&
+      (props.openOnFocus || Boolean(store.getState().query))
+    ) {
+      onInput({
         event,
-        item,
-        itemInputValue,
-        itemUrl,
+        props,
+        query: store.getState().query,
         refresh,
-        source,
-        state: store.getState(),
+        store,
         ...setters,
+      }).then(() => {
+        store.dispatch(event.key as ActionType, {
+          nextActiveItemId: props.defaultActiveItemId,
+        });
+
+        // We need to wait for the panel to open.
+        setTimeout(triggerScrollIntoView, 0);
+        triggerOnActive();
       });
+    } else {
+      store.dispatch(event.key, {});
+
+      triggerScrollIntoView();
+      triggerOnActive();
     }
   } else if (event.key === 'Escape') {
     // This prevents the default browser behavior on `input[type="search"]`

--- a/packages/autocomplete-core/src/stateReducer.ts
+++ b/packages/autocomplete-core/src/stateReducer.ts
@@ -55,12 +55,14 @@ export const stateReducer: Reducer = (state, action) => {
     case 'ArrowDown': {
       const nextState = {
         ...state,
-        activeItemId: getNextActiveItemId(
-          1,
-          state.activeItemId,
-          getItemsCount(state),
-          action.props.defaultActiveItemId
-        ),
+        activeItemId: action.payload.hasOwnProperty('nextActiveItemId')
+          ? action.payload.nextActiveItemId
+          : getNextActiveItemId(
+              1,
+              state.activeItemId,
+              getItemsCount(state),
+              action.props.defaultActiveItemId
+            ),
       };
 
       return {
@@ -90,6 +92,7 @@ export const stateReducer: Reducer = (state, action) => {
       if (state.isOpen) {
         return {
           ...state,
+          activeItemId: null,
           isOpen: false,
           completion: null,
         };
@@ -97,6 +100,7 @@ export const stateReducer: Reducer = (state, action) => {
 
       return {
         ...state,
+        activeItemId: null,
         query: '',
         status: 'idle',
         collections: [],

--- a/packages/autocomplete-core/src/types/AutocompleteStore.ts
+++ b/packages/autocomplete-core/src/types/AutocompleteStore.ts
@@ -18,7 +18,7 @@ type Action<TItem extends BaseItem, TPayload> = {
   payload: TPayload;
 };
 
-type ActionType =
+export type ActionType =
   | 'setActiveItemId'
   | 'setQuery'
   | 'setCollections'


### PR DESCRIPTION
**Summary**

With the input focused, pressing <kbd>↓</kbd> or <kbd>↑</kbd> should open the panel if it was previously closed.

**Result**

With `openOnFocus: true` or a query, and the input focused:
- Pressing <kbd>↓</kbd> will open the panel with the input focused.
- Pressing <kbd>↑</kbd> will open the panel with the last element of the list focused.

Reference: [w3c aria practices](https://w3c.github.io/aria-practices/#combobox-keyboard-interaction)
Closes https://github.com/algolia/autocomplete/issues/584