### PR TITLE
fix(js): provide fallback method for `addEventListener` on media queries

### DIFF
--- a/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
+++ b/packages/autocomplete-js/src/__tests__/autocomplete.test.ts
@@ -1,7 +1,7 @@
 import * as autocompleteShared from '@algolia/autocomplete-shared';
 import { fireEvent, waitFor } from '@testing-library/dom';
 
-import { castToJestMock } from '../../../../test/utils';
+import { castToJestMock, createMatchMedia } from '../../../../test/utils';
 import { autocomplete } from '../autocomplete';
 
 jest.mock('@algolia/autocomplete-shared', () => {
@@ -210,27 +210,16 @@ describe('autocomplete-js', () => {
       initialNbCalls
     );
 
-    const originalMatchMedia = window.matchMedia;
-
     Object.defineProperty(window, 'matchMedia', {
       writable: true,
-      value: jest.fn((query) => ({
-        matches: true,
-        media: query,
-        onchange: null,
-        addListener: jest.fn(),
-        removeListener: jest.fn(),
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      })),
+      value: createMatchMedia({ matches: true }),
     });
 
     update({ detachedMediaQuery: '' });
 
     Object.defineProperty(window, 'matchMedia', {
       writable: true,
-      value: originalMatchMedia,
+      value: createMatchMedia({}),
     });
 
     expect(autocompleteShared.generateAutocompleteId).toHaveBeenCalledTimes(

--- a/packages/autocomplete-js/src/__tests__/detached.test.ts
+++ b/packages/autocomplete-js/src/__tests__/detached.test.ts
@@ -1,30 +1,20 @@
 import { fireEvent, waitFor } from '@testing-library/dom';
 
+import { createMatchMedia } from '../../../../test/utils';
 import { autocomplete } from '../autocomplete';
 
 describe('detached', () => {
-  const originalMatchMedia = window.matchMedia;
-
   beforeAll(() => {
     Object.defineProperty(window, 'matchMedia', {
       writable: true,
-      value: jest.fn((query) => ({
-        matches: true,
-        media: query,
-        onchange: null,
-        addListener: jest.fn(),
-        removeListener: jest.fn(),
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      })),
+      value: createMatchMedia({ matches: true }),
     });
   });
 
   afterAll(() => {
     Object.defineProperty(window, 'matchMedia', {
       writable: true,
-      value: originalMatchMedia,
+      value: createMatchMedia({}),
     });
   });
 

--- a/packages/autocomplete-js/src/__tests__/detachedMediaQuery.test.ts
+++ b/packages/autocomplete-js/src/__tests__/detachedMediaQuery.test.ts
@@ -1,29 +1,11 @@
+import { createMatchMedia } from '../../../../test/utils';
 import { autocomplete } from '../autocomplete';
 
 describe('detachedMediaQuery', () => {
-  const originalMatchMedia = window.matchMedia;
-  const addEventListener = jest.fn();
-
-  beforeAll(() => {
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: jest.fn((query) => ({
-        matches: true,
-        media: query,
-        onchange: null,
-        addListener: jest.fn(),
-        removeListener: jest.fn(),
-        addEventListener,
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      })),
-    });
-  });
-
   afterAll(() => {
     Object.defineProperty(window, 'matchMedia', {
       writable: true,
-      value: originalMatchMedia,
+      value: createMatchMedia({}),
     });
   });
 
@@ -32,14 +14,11 @@ describe('detachedMediaQuery', () => {
 
     Object.defineProperty(window, 'matchMedia', {
       writable: true,
-      value: jest.fn((query) => ({
+      value: createMatchMedia({
         matches: true,
-        media: query,
-        onchange: null,
         addListener,
-        removeListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      })),
+        addEventListener: undefined,
+      }),
     });
 
     const container = document.createElement('div');
@@ -66,6 +45,5 @@ describe('detachedMediaQuery', () => {
     });
 
     expect(addListener).toHaveBeenCalledTimes(1);
-    expect(addEventListener).not.toHaveBeenCalled();
   });
 });

--- a/packages/autocomplete-js/src/__tests__/detachedMediaQuery.test.ts
+++ b/packages/autocomplete-js/src/__tests__/detachedMediaQuery.test.ts
@@ -27,7 +27,7 @@ describe('detachedMediaQuery', () => {
     });
   });
 
-  test('fallback to the deprecated `addListener` if `addEventListener` is undefined', () => {
+  test('falls back to the deprecated `addListener` if `addEventListener` is undefined', () => {
     const addListener = jest.fn();
 
     Object.defineProperty(window, 'matchMedia', {

--- a/packages/autocomplete-js/src/__tests__/detachedMediaQuery.test.ts
+++ b/packages/autocomplete-js/src/__tests__/detachedMediaQuery.test.ts
@@ -1,4 +1,4 @@
-import { createMatchMedia } from '../../../../test/utils';
+import { createMatchMedia, createSource } from '../../../../test/utils';
 import { autocomplete } from '../autocomplete';
 
 describe('detachedMediaQuery', () => {
@@ -30,10 +30,7 @@ describe('detachedMediaQuery', () => {
       getSources() {
         return [
           {
-            sourceId: 'testSource',
-            getItems() {
-              return [{ label: 'Item 1' }];
-            },
+            ...createSource({}),
             templates: {
               item({ item }) {
                 return item.label;

--- a/packages/autocomplete-js/src/__tests__/detachedMediaQuery.test.ts
+++ b/packages/autocomplete-js/src/__tests__/detachedMediaQuery.test.ts
@@ -1,3 +1,71 @@
+import { autocomplete } from '../autocomplete';
+
 describe('detachedMediaQuery', () => {
-  test.todo('tests');
+  const originalMatchMedia = window.matchMedia;
+  const addEventListener = jest.fn();
+
+  beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn((query) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener,
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: originalMatchMedia,
+    });
+  });
+
+  test('fallback to the deprecated `addListener` if `addEventListener` is undefined', () => {
+    const addListener = jest.fn();
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn((query) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener,
+        removeListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    autocomplete<{ label: string }>({
+      id: 'autocomplete',
+      detachedMediaQuery: '',
+      container,
+      getSources() {
+        return [
+          {
+            sourceId: 'testSource',
+            getItems() {
+              return [{ label: 'Item 1' }];
+            },
+            templates: {
+              item({ item }) {
+                return item.label;
+              },
+            },
+          },
+        ];
+      },
+    });
+
+    expect(addListener).toHaveBeenCalledTimes(1);
+    expect(addEventListener).not.toHaveBeenCalled();
+  });
 });

--- a/packages/autocomplete-js/src/__tests__/translations.test.ts
+++ b/packages/autocomplete-js/src/__tests__/translations.test.ts
@@ -1,5 +1,6 @@
 import { waitFor } from '@testing-library/dom';
 
+import { createMatchMedia } from '../../../../test/utils';
 import { autocomplete } from '../autocomplete';
 
 describe('translations', () => {
@@ -46,28 +47,17 @@ describe('translations', () => {
   });
 
   describe('detached DOM', () => {
-    const originalMatchMedia = window.matchMedia;
-
     beforeAll(() => {
       Object.defineProperty(window, 'matchMedia', {
         writable: true,
-        value: jest.fn((query) => ({
-          matches: true,
-          media: query,
-          onchange: null,
-          addListener: jest.fn(),
-          removeListener: jest.fn(),
-          addEventListener: jest.fn(),
-          removeEventListener: jest.fn(),
-          dispatchEvent: jest.fn(),
-        })),
+        value: createMatchMedia({ matches: true }),
       });
     });
 
     afterAll(() => {
       Object.defineProperty(window, 'matchMedia', {
         writable: true,
-        value: originalMatchMedia,
+        value: createMatchMedia({}),
       });
     });
 

--- a/packages/autocomplete-js/src/autocomplete.ts
+++ b/packages/autocomplete-js/src/autocomplete.ts
@@ -301,6 +301,9 @@ export function autocomplete<TItem extends BaseItem>(
 
     toggleModalClassname(isModalDetachedMql.matches);
 
+    // Prior to Safari 14, `MediaQueryList` isn't based on `EventTarget`,
+    // so we must use `addListener` and `removeListener` to observe media query lists.
+    // See https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener
     const hasModernEventListener = Boolean(isModalDetachedMql.addEventListener);
 
     hasModernEventListener

--- a/packages/autocomplete-js/src/autocomplete.ts
+++ b/packages/autocomplete-js/src/autocomplete.ts
@@ -301,10 +301,16 @@ export function autocomplete<TItem extends BaseItem>(
 
     toggleModalClassname(isModalDetachedMql.matches);
 
-    isModalDetachedMql.addEventListener('change', onChange);
+    const hasModernEventListener = Boolean(isModalDetachedMql.addEventListener);
+
+    hasModernEventListener
+      ? isModalDetachedMql.addEventListener('change', onChange)
+      : isModalDetachedMql.addListener(onChange);
 
     return () => {
-      isModalDetachedMql.removeEventListener('change', onChange);
+      hasModernEventListener
+        ? isModalDetachedMql.removeEventListener('change', onChange)
+        : isModalDetachedMql.removeListener(onChange);
     };
   });
 

--- a/scripts/jest/setupTests.ts
+++ b/scripts/jest/setupTests.ts
@@ -1,3 +1,5 @@
+import { createMatchMedia } from '../../test/utils';
+
 import { toWarnDev } from './matchers';
 
 expect.extend({ toWarnDev });
@@ -6,14 +8,5 @@ global.console.warn = jest.fn();
 
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
-  value: jest.fn((query) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: jest.fn(),
-    removeListener: jest.fn(),
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
-  })),
+  value: createMatchMedia({}),
 });

--- a/test/utils/createMatchMedia.ts
+++ b/test/utils/createMatchMedia.ts
@@ -1,0 +1,24 @@
+type MatchMediaProps = Partial<{
+  matches: boolean;
+  media: string;
+  onchange: null;
+  addListener: jest.Mock;
+  removeListener: jest.Mock;
+  addEventListener: jest.Mock;
+  removeEventListener: jest.Mock;
+  dispatchEvent: jest.Mock;
+}>;
+
+export const createMatchMedia = (props: MatchMediaProps) => {
+  return jest.fn((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+    ...props,
+  }));
+};

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './castToJestMock';
 export * from './createApiResponse';
 export * from './createCollection';
+export * from './createMatchMedia';
 export * from './createNavigator';
 export * from './createPlayground';
 export * from './createScopeApi';


### PR DESCRIPTION
**Summary**

`addEventListener` on media queries isn't supported for iOS <= 13.6, which causes Autocomplete to crash the application. We now provide a fallback solution to the deprecated method `addListener`.

**Result**

Autocomplete no longer crashes on iOS <= 13.6

**Video**

Following the steps of https://github.com/algolia/autocomplete/issues/597, the device is an iPhone 11 running on iOS 13.6.

- At the beginning, we can see the sandbox of the issue (without the workaround) throwing an error. [sandbox](https://codesandbox.io/s/blazing-star-ke0de?file=/index.html)
- The second sandbox is the one from this commit, with the code from `app.tsx` (from the one above) copy pasted. [sandbox](https://codesandbox.io/s/algoliaautocomplete-example-starter-algolia-forked-jxl1l?file=/app.tsx)

https://user-images.githubusercontent.com/20689156/121390377-9b4b4c00-c94d-11eb-8369-4412957304b0.mov

Closes https://github.com/algolia/autocomplete/issues/597