### PR TITLE
fix(core): trigger invariant when user doesn't return anything from `getItems`

### DIFF
--- a/packages/autocomplete-core/src/__tests__/getSources.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getSources.test.ts
@@ -6,6 +6,7 @@ import {
   runAllMicroTasks,
 } from '../../../../test/utils';
 import { createAutocomplete } from '../createAutocomplete';
+import * as handlers from '../onInput';
 
 describe('getSources', () => {
   test('gets calls on input', () => {
@@ -109,5 +110,26 @@ describe('getSources', () => {
     await runAllMicroTasks();
 
     expect(onStateChange.mock.calls.pop()[0].state.collections).toHaveLength(2);
+  });
+
+  test('with nothing returned from getItems throws', async () => {
+    const spy = jest.spyOn(handlers, 'onInput');
+
+    const { inputElement } = createPlayground(createAutocomplete, {
+      getSources() {
+        return [createSource({ getItems: () => {} })];
+      },
+    });
+
+    await expect(() => {
+      inputElement.focus();
+      userEvent.type(inputElement, 'a');
+
+      return spy.mock.results[0].value;
+    }).rejects.toThrow(
+      '[Autocomplete] The `getItems` function should return or resolve to an array of items.'
+    );
+
+    spy.mockRestore();
   });
 });

--- a/packages/autocomplete-core/src/__tests__/getSources.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getSources.test.ts
@@ -117,7 +117,7 @@ describe('getSources', () => {
 
     const { inputElement } = createPlayground(createAutocomplete, {
       getSources() {
-        return [createSource({ getItems: () => {} })];
+        return [createSource({ sourceId: 'source1', getItems: () => {} })];
       },
     });
 
@@ -127,7 +127,7 @@ describe('getSources', () => {
 
       return spy.mock.results[0].value;
     }).rejects.toThrow(
-      '[Autocomplete] The `getItems` function should return or resolve to an array of items.'
+      '[Autocomplete] The `getItems` function must return an array of items but returned type "object":\n\n[\n  null\n]'
     );
 
     spy.mockRestore();

--- a/packages/autocomplete-core/src/__tests__/getSources.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getSources.test.ts
@@ -127,7 +127,7 @@ describe('getSources', () => {
 
       return spy.mock.results[0].value;
     }).rejects.toThrow(
-      '[Autocomplete] The `getItems` function must return an array of items but returned type "object":\n\n[\n  null\n]'
+      '[Autocomplete] The `getItems` function from source "source1" must return an array of items but returned type "object":\n\n[\n  null\n]'
     );
 
     spy.mockRestore();

--- a/packages/autocomplete-core/src/__tests__/getSources.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getSources.test.ts
@@ -127,7 +127,7 @@ describe('getSources', () => {
 
       return spy.mock.results[0].value;
     }).rejects.toThrow(
-      '[Autocomplete] The `getItems` function from source "source1" must return an array of items but returned type "object":\n\n[\n  null\n]'
+      '[Autocomplete] The `getItems` function from source "source1" must return an array of items but returned undefined.\n\nDid you forget to return items?\n\nSee: https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/sources/#param-getitems'
     );
 
     spy.mockRestore();

--- a/packages/autocomplete-core/src/onInput.ts
+++ b/packages/autocomplete-core/src/onInput.ts
@@ -1,5 +1,3 @@
-import { invariant } from '@algolia/autocomplete-shared';
-
 import { preResolve, resolve, postResolve } from './resolve';
 import {
   AutocompleteScopeApi,

--- a/packages/autocomplete-core/src/onInput.ts
+++ b/packages/autocomplete-core/src/onInput.ts
@@ -1,3 +1,5 @@
+import { invariant } from '@algolia/autocomplete-shared';
+
 import { preResolve, resolve, postResolve } from './resolve';
 import {
   AutocompleteScopeApi,
@@ -90,9 +92,14 @@ export function onInput<TItem extends BaseItem>({
               state: store.getState(),
               ...setters,
             })
-          ).then((itemsOrDescription) =>
-            preResolve<TItem>(itemsOrDescription, source.sourceId)
-          );
+          ).then((itemsOrDescription) => {
+            invariant(
+              itemsOrDescription !== undefined,
+              'The `getItems` function should return or resolve to an array of items.'
+            );
+
+            return preResolve<TItem>(itemsOrDescription, source.sourceId);
+          });
         })
       )
         .then(resolve)

--- a/packages/autocomplete-core/src/onInput.ts
+++ b/packages/autocomplete-core/src/onInput.ts
@@ -92,14 +92,9 @@ export function onInput<TItem extends BaseItem>({
               state: store.getState(),
               ...setters,
             })
-          ).then((itemsOrDescription) => {
-            invariant(
-              itemsOrDescription !== undefined,
-              'The `getItems` function should return or resolve to an array of items.'
-            );
-
-            return preResolve<TItem>(itemsOrDescription, source.sourceId);
-          });
+          ).then((itemsOrDescription) =>
+            preResolve<TItem>(itemsOrDescription, source.sourceId)
+          );
         })
       )
         .then(resolve)

--- a/packages/autocomplete-core/src/resolve.ts
+++ b/packages/autocomplete-core/src/resolve.ts
@@ -171,12 +171,25 @@ export function postResolve<TItem extends BaseItem>(
       : results;
 
     invariant(
-      Array.isArray(items) && (items as Array<typeof items>).every(Boolean),
+      Array.isArray(items),
       `The \`getItems\` function from source "${
         source.sourceId
       }" must return an array of items but returned type ${JSON.stringify(
         typeof items
       )}:\n\n${JSON.stringify(items, null, 2)}`
+    );
+
+    invariant(
+      (items as Array<typeof items>).every(Boolean),
+      `The \`getItems\` function from source "${
+        source.sourceId
+      }" must return an array of items but returned ${JSON.stringify(
+        undefined
+      )}.
+
+Did you forget to return items?
+
+See: https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/sources/#param-getitems`
     );
 
     return {

--- a/packages/autocomplete-core/src/resolve.ts
+++ b/packages/autocomplete-core/src/resolve.ts
@@ -172,7 +172,9 @@ export function postResolve<TItem extends BaseItem>(
 
     invariant(
       Array.isArray(items) && (items as Array<typeof items>).every(Boolean),
-      `The \`getItems\` function must return an array of items but returned type ${JSON.stringify(
+      `The \`getItems\` function from source "${
+        source.sourceId
+      }" must return an array of items but returned type ${JSON.stringify(
         typeof items
       )}:\n\n${JSON.stringify(items, null, 2)}`
     );

--- a/packages/autocomplete-core/src/resolve.ts
+++ b/packages/autocomplete-core/src/resolve.ts
@@ -27,7 +27,7 @@ function isDescription<TItem extends BaseItem>(
 function isRequesterDescription<TItem extends BaseItem>(
   description: TItem[] | TItem[][] | RequesterDescription<TItem>
 ): description is RequesterDescription<TItem> {
-  return Boolean((description as RequesterDescription<TItem>).execute);
+  return Boolean((description as RequesterDescription<TItem>)?.execute);
 }
 
 type PackedDescription<TItem extends BaseItem> = {
@@ -171,7 +171,7 @@ export function postResolve<TItem extends BaseItem>(
       : results;
 
     invariant(
-      Array.isArray(items),
+      Array.isArray(items) && (items as Array<typeof items>).every(Boolean),
       `The \`getItems\` function must return an array of items but returned type ${JSON.stringify(
         typeof items
       )}:\n\n${JSON.stringify(items, null, 2)}`

--- a/packages/autocomplete-core/src/resolve.ts
+++ b/packages/autocomplete-core/src/resolve.ts
@@ -176,7 +176,9 @@ export function postResolve<TItem extends BaseItem>(
         source.sourceId
       }" must return an array of items but returned type ${JSON.stringify(
         typeof items
-      )}:\n\n${JSON.stringify(items, null, 2)}`
+      )}:\n\n${JSON.stringify(items, null, 2)}.
+
+See: https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/sources/#param-getitems`
     );
 
     invariant(


### PR DESCRIPTION
When users don't return anything from `getItems`, they get an unhelpful runtime error:

```txt
"Cannot read property 'execute' of undefined"
```

**Reproduction link:** https://codesandbox.io/s/wizardly-rgb-i69uy (try typing, then see error)

This is because the Requester API determines whether the returned value is a requester description by looking for an `execute` property on them. If there's no return statement in `getItems`, the value is `undefined` and the runtime throws.

This is fine in production, but not too helpful during development, especially for non-TypeScript users who won't get a type error in their editor. This PR therefore adds an invariant to provide a more helpful development error.

## Tests

The test uses a spy on `onInput` because at the level where we're testing, there's no way to track the error. If we wanted to avoid it, it would require testing the error at a lower level, in `onInput.ts` (which currently doesn't have a test suite).

The current test is closer to what the user would do. Both strategies would leak implementation details, but this one being more expressive regarding what behavior triggers what consequence, I think it's better.