### PR TITLE
fix: use user-provided panelLayout class

### DIFF
--- a/packages/autocomplete-js/src/render.tsx
+++ b/packages/autocomplete-js/src/render.tsx
@@ -178,7 +178,7 @@ export function renderPanel<TItem extends BaseItem>(
 
   const children = (
     <Fragment>
-      <div className="aa-PanelLayout aa-Panel--scrollable">{sections}</div>
+      <div className={classNames.panelLayout + ' aa-Panel--scrollable'}>{sections}</div>
       <div className="aa-GradientBottom" />
     </Fragment>
   );


### PR DESCRIPTION
I was trying to pass in a custom panelLayout class, as seems to be a documented feature, but it didn't appear to be getting applied anywhere. I think this fixes the issue.