### PR TITLE
fix(js): use user-provided panelLayout class

### DIFF
--- a/packages/autocomplete-js/src/getDefaultOptions.ts
+++ b/packages/autocomplete-js/src/getDefaultOptions.ts
@@ -44,7 +44,7 @@ const defaultClassNames: AutocompleteClassNames = {
   list: 'aa-List',
   loadingIndicator: 'aa-LoadingIndicator',
   panel: 'aa-Panel',
-  panelLayout: 'aa-PanelLayout',
+  panelLayout: 'aa-PanelLayout aa-Panel--scrollable',
   root: 'aa-Autocomplete',
   source: 'aa-Source',
   sourceFooter: 'aa-SourceFooter',

--- a/packages/autocomplete-js/src/render.tsx
+++ b/packages/autocomplete-js/src/render.tsx
@@ -178,7 +178,7 @@ export function renderPanel<TItem extends BaseItem>(
 
   const children = (
     <Fragment>
-      <div className="aa-PanelLayout aa-Panel--scrollable">{sections}</div>
+      <div className={classNames.panelLayout}>{sections}</div>
       <div className="aa-GradientBottom" />
     </Fragment>
   );


### PR DESCRIPTION
Thanks @ethanresnick for pointing this out!

closes #627

It looks like the panelLayout class wasn't used, because two class names needed to be added. This isn't used in any other place, so any panel layout is also a scrollable panel as far as I can tell :)