### PR TITLE
fix: decycle potentially cyclic structures before serializing

### DIFF
--- a/packages/autocomplete-core/src/__tests__/getSources.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getSources.test.ts
@@ -112,6 +112,29 @@ describe('getSources', () => {
     expect(onStateChange.mock.calls.pop()[0].state.collections).toHaveLength(2);
   });
 
+  test('with circular references returned from getItems does not throw', () => {
+    const { inputElement } = createPlayground(createAutocomplete, {
+      getSources() {
+        return [
+          createSource({
+            sourceId: 'source1',
+            getItems: () => {
+              const obj = { a: 'b', self: null };
+              obj.self = obj;
+
+              return [obj];
+            },
+          }),
+        ];
+      },
+    });
+
+    expect(() => {
+      inputElement.focus();
+      userEvent.type(inputElement, 'a');
+    }).not.toThrow();
+  });
+
   test('with nothing returned from getItems throws', async () => {
     const spy = jest.spyOn(handlers, 'onInput');
 

--- a/packages/autocomplete-core/src/__tests__/getSources.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getSources.test.ts
@@ -119,10 +119,10 @@ describe('getSources', () => {
           createSource({
             sourceId: 'source1',
             getItems: () => {
-              const obj = { a: 'b', self: null };
-              obj.self = obj;
+              const circular = { a: 'b', self: null };
+              circular.self = circular;
 
-              return [obj];
+              return [circular];
             },
           }),
         ];

--- a/packages/autocomplete-core/src/resolve.ts
+++ b/packages/autocomplete-core/src/resolve.ts
@@ -172,7 +172,7 @@ export function postResolve<TItem extends BaseItem>(
 
     invariant(
       Array.isArray(items),
-      `The \`getItems\` function from source "${
+      () => `The \`getItems\` function from source "${
         source.sourceId
       }" must return an array of items but returned type ${JSON.stringify(
         typeof items

--- a/packages/autocomplete-core/src/resolve.ts
+++ b/packages/autocomplete-core/src/resolve.ts
@@ -4,7 +4,7 @@ import type {
   RequesterDescription,
   TransformResponse,
 } from '@algolia/autocomplete-preset-algolia';
-import { invariant } from '@algolia/autocomplete-shared';
+import { decycle, invariant } from '@algolia/autocomplete-shared';
 import {
   MultipleQueriesQuery,
   SearchForFacetValuesResponse,
@@ -176,7 +176,7 @@ export function postResolve<TItem extends BaseItem>(
         source.sourceId
       }" must return an array of items but returned type ${JSON.stringify(
         typeof items
-      )}:\n\n${JSON.stringify(items, null, 2)}.
+      )}:\n\n${JSON.stringify(decycle(items), null, 2)}.
 
 See: https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/sources/#param-getitems`
     );

--- a/packages/autocomplete-core/src/utils/__tests__/getNormalizedSources.test.ts
+++ b/packages/autocomplete-core/src/utils/__tests__/getNormalizedSources.test.ts
@@ -67,10 +67,10 @@ describe('getNormalizedSources', () => {
   });
 
   test('with wrong `getSources` function return type containing circular references triggers invariant', async () => {
-    const cyclic = { self: null };
-    cyclic.self = cyclic;
+    const circular = { self: null };
+    circular.self = circular;
 
-    const getSources = () => cyclic;
+    const getSources = () => circular;
     const params = {
       query: '',
       state: createState({}),

--- a/packages/autocomplete-core/src/utils/__tests__/getNormalizedSources.test.ts
+++ b/packages/autocomplete-core/src/utils/__tests__/getNormalizedSources.test.ts
@@ -66,6 +66,25 @@ describe('getNormalizedSources', () => {
     );
   });
 
+  test('with wrong `getSources` function return type containing circular references triggers invariant', async () => {
+    const cyclic = { self: null };
+    cyclic.self = cyclic;
+
+    const getSources = () => cyclic;
+    const params = {
+      query: '',
+      state: createState({}),
+      ...createScopeApi(),
+    };
+
+    // @ts-expect-error
+    await expect(getNormalizedSources(getSources, params)).rejects.toEqual(
+      new Error(
+        '[Autocomplete] The `getSources` function must return an array of sources but returned type "object":\n\n{\n  "self": "[Circular]"\n}'
+      )
+    );
+  });
+
   test('with missing `sourceId` triggers invariant', async () => {
     const getSources = () => [
       {

--- a/packages/autocomplete-core/src/utils/getNormalizedSources.ts
+++ b/packages/autocomplete-core/src/utils/getNormalizedSources.ts
@@ -20,9 +20,10 @@ export function getNormalizedSources<TItem extends BaseItem>(
   return Promise.resolve(getSources(params)).then((sources) => {
     invariant(
       Array.isArray(sources),
-      `The \`getSources\` function must return an array of sources but returned type ${JSON.stringify(
-        typeof sources
-      )}:\n\n${JSON.stringify(decycle(sources), null, 2)}`
+      () =>
+        `The \`getSources\` function must return an array of sources but returned type ${JSON.stringify(
+          typeof sources
+        )}:\n\n${JSON.stringify(decycle(sources), null, 2)}`
     );
 
     return Promise.all(

--- a/packages/autocomplete-core/src/utils/getNormalizedSources.ts
+++ b/packages/autocomplete-core/src/utils/getNormalizedSources.ts
@@ -1,4 +1,4 @@
-import { invariant } from '@algolia/autocomplete-shared';
+import { invariant, decycle } from '@algolia/autocomplete-shared';
 
 import {
   AutocompleteSource,
@@ -22,7 +22,7 @@ export function getNormalizedSources<TItem extends BaseItem>(
       Array.isArray(sources),
       `The \`getSources\` function must return an array of sources but returned type ${JSON.stringify(
         typeof sources
-      )}:\n\n${JSON.stringify(sources, null, 2)}`
+      )}:\n\n${JSON.stringify(decycle(sources), null, 2)}`
     );
 
     return Promise.all(

--- a/packages/autocomplete-shared/src/__tests__/decycle.test.ts
+++ b/packages/autocomplete-shared/src/__tests__/decycle.test.ts
@@ -1,22 +1,24 @@
 import { decycle } from '../decycle';
 
 describe('decycle', () => {
-  test('leaves objects with no circular references intact', () => {
-    const obj = { a: 1 };
-    const subject = {
-      a: 'b',
-      c: { d: [obj, () => {}, null, false, undefined] },
-    };
+  if (__DEV__) {
+    test('leaves objects with no circular references intact', () => {
+      const obj = { a: 1 };
+      const subject = {
+        a: 'b',
+        c: { d: [obj, () => {}, null, false, undefined] },
+      };
 
-    expect(decycle(subject)).toEqual({
-      a: 'b',
-      c: { d: [{ a: 1 }, expect.any(Function), null, false, undefined] },
+      expect(decycle(subject)).toEqual({
+        a: 'b',
+        c: { d: [{ a: 1 }, expect.any(Function), null, false, undefined] },
+      });
     });
-  });
-  test('replaces circular references', () => {
-    const circular = { a: 'b', self: null };
-    circular.self = circular;
+    test('replaces circular references', () => {
+      const circular = { a: 'b', self: null };
+      circular.self = circular;
 
-    expect(decycle(circular)).toEqual({ a: 'b', self: '[Circular]' });
-  });
+      expect(decycle(circular)).toEqual({ a: 'b', self: '[Circular]' });
+    });
+  }
 });

--- a/packages/autocomplete-shared/src/__tests__/decycle.test.ts
+++ b/packages/autocomplete-shared/src/__tests__/decycle.test.ts
@@ -1,0 +1,22 @@
+import { decycle } from '../decycle';
+
+describe('decycle', () => {
+  test('leaves objects with no circular references intact', () => {
+    const obj = { a: 1 };
+    const subject = {
+      a: 'b',
+      c: { d: [obj, () => {}, null, false, undefined] },
+    };
+
+    expect(decycle(subject)).toEqual({
+      a: 'b',
+      c: { d: [{ a: 1 }, expect.any(Function), null, false, undefined] },
+    });
+  });
+  test('replaces circular references', () => {
+    const circular = { a: 'b', self: null };
+    circular.self = circular;
+
+    expect(decycle(circular)).toEqual({ a: 'b', self: '[Circular]' });
+  });
+});

--- a/packages/autocomplete-shared/src/__tests__/decycle.test.ts
+++ b/packages/autocomplete-shared/src/__tests__/decycle.test.ts
@@ -3,13 +3,13 @@ import { decycle } from '../decycle';
 describe('decycle', () => {
   if (__DEV__) {
     test('leaves objects with no circular references intact', () => {
-      const obj = { a: 1 };
-      const subject = {
+      const ref = { a: 1 };
+      const obj = {
         a: 'b',
-        c: { d: [obj, () => {}, null, false, undefined] },
+        c: { d: [ref, () => {}, null, false, undefined] },
       };
 
-      expect(decycle(subject)).toEqual({
+      expect(decycle(obj)).toEqual({
         a: 'b',
         c: { d: [{ a: 1 }, expect.any(Function), null, false, undefined] },
       });

--- a/packages/autocomplete-shared/src/__tests__/invariant.test.ts
+++ b/packages/autocomplete-shared/src/__tests__/invariant.test.ts
@@ -13,5 +13,22 @@ describe('invariant', () => {
         invariant(true, 'invariant');
       }).not.toThrow();
     });
+
+    test('lazily instantiates message', () => {
+      const spy1 = jest.fn(() => 'invariant');
+      const spy2 = jest.fn(() => 'invariant');
+
+      expect(() => {
+        invariant(false, spy1);
+      }).toThrow('[Autocomplete] invariant');
+
+      expect(spy1).toHaveBeenCalledTimes(1);
+
+      expect(() => {
+        invariant(true, spy2);
+      }).not.toThrow('[Autocomplete] invariant');
+
+      expect(spy2).not.toHaveBeenCalled();
+    });
   }
 });

--- a/packages/autocomplete-shared/src/decycle.ts
+++ b/packages/autocomplete-shared/src/decycle.ts
@@ -1,8 +1,9 @@
 /**
  * Decycles objects with circular references.
+ * This is used to print cyclic structures in development environment only.
  */
 export function decycle(obj: any, seen: any[] = []) {
-  if (!obj || typeof obj !== 'object') {
+  if (!__DEV__ || !obj || typeof obj !== 'object') {
     return obj;
   }
 

--- a/packages/autocomplete-shared/src/decycle.ts
+++ b/packages/autocomplete-shared/src/decycle.ts
@@ -2,16 +2,16 @@
  * Decycles objects with circular references.
  * This is used to print cyclic structures in development environment only.
  */
-export function decycle(obj: any, seen: any[] = []) {
+export function decycle(obj: any, seen = new Set()) {
   if (!__DEV__ || !obj || typeof obj !== 'object') {
     return obj;
   }
 
-  if (seen.includes(obj)) {
+  if (seen.has(obj)) {
     return '[Circular]';
   }
 
-  const newSeen = seen.concat([obj]);
+  const newSeen = seen.add(obj);
 
   if (Array.isArray(obj)) {
     return obj.map((x) => decycle(x, newSeen));

--- a/packages/autocomplete-shared/src/decycle.ts
+++ b/packages/autocomplete-shared/src/decycle.ts
@@ -1,0 +1,22 @@
+/**
+ * Decycles objects with circular references.
+ */
+export function decycle(obj: any, seen: any[] = []) {
+  if (!obj || typeof obj !== 'object') {
+    return obj;
+  }
+
+  if (seen.includes(obj)) {
+    return '[Circular]';
+  }
+
+  const newSeen = seen.concat([obj]);
+
+  if (Array.isArray(obj)) {
+    return obj.map((x) => decycle(x, newSeen));
+  }
+
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => [key, decycle(value, newSeen)])
+  );
+}

--- a/packages/autocomplete-shared/src/index.ts
+++ b/packages/autocomplete-shared/src/index.ts
@@ -1,5 +1,6 @@
 export * from './createRef';
 export * from './debounce';
+export * from './decycle';
 export * from './generateAutocompleteId';
 export * from './getAttributeValueByPath';
 export * from './getItemsCount';

--- a/packages/autocomplete-shared/src/invariant.ts
+++ b/packages/autocomplete-shared/src/invariant.ts
@@ -12,8 +12,6 @@ export function invariant(
   }
 
   if (!condition) {
-    const _message = typeof message === 'string' ? message : message();
-
-    throw new Error(`[Autocomplete] ${_message}`);
+    throw new Error(`[Autocomplete] ${typeof message === 'function' ? message() : message}`);
   }
 }

--- a/packages/autocomplete-shared/src/invariant.ts
+++ b/packages/autocomplete-shared/src/invariant.ts
@@ -3,12 +3,17 @@
  * This is used to make development a better experience to provide guidance as
  * to where the error comes from.
  */
-export function invariant(condition: boolean, message: string) {
+export function invariant(
+  condition: boolean,
+  message: string | (() => string)
+) {
   if (!__DEV__) {
     return;
   }
 
   if (!condition) {
-    throw new Error(`[Autocomplete] ${message}`);
+    const _message = typeof message === 'string' ? message : message();
+
+    throw new Error(`[Autocomplete] ${_message}`);
   }
 }

--- a/packages/autocomplete-shared/src/invariant.ts
+++ b/packages/autocomplete-shared/src/invariant.ts
@@ -12,6 +12,8 @@ export function invariant(
   }
 
   if (!condition) {
-    throw new Error(`[Autocomplete] ${typeof message === 'function' ? message() : message}`);
+    throw new Error(
+      `[Autocomplete] ${typeof message === 'function' ? message() : message}`
+    );
   }
 }


### PR DESCRIPTION
This introduces a `decycle` utility to replace cyclic references in objects before serializing them with `JSON.stringify`.

It uses a slightly modified version of Crockford's [cycle.js](https://github.com/douglascrockford/JSON-js/blob/master/cycle.js), [which MDN recommends](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#issue_with_json.stringify_when_serializing_circular_references). This works better than `JSON.stringify`'s `replacer`, because the latter walks every node in the object, making it difficult to preserve non-circular structures like the following:

```js
const a = { a: 1 };
const obj = [a, a]; // JSON.strinigfy can handle this, we don't want to end up with `[{ "a": 1 }, "[Circular]"]`
```

Whenever a circular reference is met, it's replaced with `[Circular]` (_à la_ Jest).

```json
{
  "self": "[Circular]"
}
```

If sources contain complex objects (e.g., VNodes with SVGs), decycling could have a negative impact on performance. I've therefore introduced a change to `invariant`, making it accept `message` in the form of a function to execute only when the condition isn't met.

fixes #618