### PR TITLE
feat(theme): provide non-minified theme

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -25,7 +25,7 @@
       "maxSize": "4 kB"
     },
     {
-      "path": "packages/autocomplete-theme-classic/dist/theme.css",
+      "path": "packages/autocomplete-theme-classic/dist/theme.min.css",
       "maxSize": "4.25 kB"
     }
   ]

--- a/packages/autocomplete-theme-classic/package.json
+++ b/packages/autocomplete-theme-classic/package.json
@@ -15,12 +15,14 @@
   "files": [
     "dist/"
   ],
-  "main": "dist/theme.css",
-  "unpkg": "dist/theme.css",
-  "jsdelivr": "dist/theme.css",
+  "main": "dist/theme.min.css",
+  "unpkg": "dist/theme.min.css",
+  "jsdelivr": "dist/theme.min.css",
   "scripts": {
     "build:clean": "rm -rf ./dist",
-    "build:css": "node ../../scripts/buildCss.mjs src/theme.scss dist/theme.css",
+    "build:css": "yarn build:css:minified && yarn build:css:unminified",
+    "build:css:minified": "MINIFIED=TRUE node ../../scripts/buildCss.mjs src/theme.scss dist/theme.min.css",
+    "build:css:unminified": "node ../../scripts/buildCss.mjs src/theme.scss dist/theme.css",
     "build": "yarn build:clean && yarn build:css",
     "on:change": "yarn build:css",
     "prepare": "yarn build:css",

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,21 +1,23 @@
+import sass from '@csstools/postcss-sass';
 import autoprefixer from 'autoprefixer';
 import cssnano from 'cssnano';
 import color from 'postcss-color-rgb';
 import comment from 'postcss-comment';
-import sass from '@csstools/postcss-sass';
 import presetEnv from 'postcss-preset-env';
+
+const MINIFIED = process.env.MINIFIED;
+const plugins = [
+  presetEnv({
+    features: {
+      'nesting-rules': false,
+    },
+  }),
+  color,
+  sass,
+  autoprefixer,
+];
 
 export default {
   parser: comment,
-  plugins: [
-    presetEnv({
-      features: {
-        'nesting-rules': false,
-      },
-    }),
-    color,
-    sass,
-    autoprefixer,
-    cssnano,
-  ],
+  plugins: MINIFIED ? [...plugins, cssnano] : plugins,
 };


### PR DESCRIPTION
**Summary**

Users were not able to build `create-react-app` applications when using the autocomplete theme due to a postcss bug with the minified version. See https://github.com/algolia/autocomplete/issues/626 for more details.

We now provide a non-minified version of the theme as a workaround to prevent this issue.

**Result**
- The main file is still the minified version, but is now called `theme.min.css`
- The non-minified version is available at `@algolia/autocomplete-theme-classic/dist/theme.css`

Closes https://github.com/algolia/autocomplete/issues/626