### PR TITLE
build(jest): map modules to sources during tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,4 +14,7 @@ module.exports = {
     __DEV__: true,
     __TEST__: true,
   },
+  moduleNameMapper: {
+    '^@algolia/autocomplete-(.*)$': '<rootDir>/packages/autocomplete-$1/src/',
+  },
 };


### PR DESCRIPTION
## Description

**This maps imports of Autocomplete libraries to their source code (instead of the build) during tests.** This creates better DX as we no longer need to rebuild updated modules when we need to test other modules that depend on them.