### PR TITLE
refactor(examples): simplify code

### DIFF
--- a/examples/twitter-compose-with-typeahead/src/App.tsx
+++ b/examples/twitter-compose-with-typeahead/src/App.tsx
@@ -7,7 +7,7 @@ import './App.css';
 export function App() {
   return (
     <div className="container">
-      <Autocomplete placeholder="What's up?" defaultActiveItemId={0} />
+      <Autocomplete placeholder="What's up?" />
     </div>
   );
 }

--- a/examples/twitter-compose-with-typeahead/src/Autocomplete.tsx
+++ b/examples/twitter-compose-with-typeahead/src/Autocomplete.tsx
@@ -24,6 +24,7 @@ export function Autocomplete(
   const { autocomplete, state } = useAutocomplete({
     ...props,
     id: 'twitter-autocomplete',
+    defaultActiveItemId: 0,
     getSources({ query }) {
       const cursorPosition = inputRef.current?.selectionEnd || 0;
       const activeToken = getActiveToken(query, cursorPosition);

--- a/examples/twitter-compose-with-typeahead/src/utils/getActiveToken.ts
+++ b/examples/twitter-compose-with-typeahead/src/utils/getActiveToken.ts
@@ -1,5 +1,5 @@
-export function getActiveToken(query: string, cursorPosition: number) {
-  const tokenizedQuery = query.split(/[\s\n]/).reduce((acc, word, index) => {
+export function getActiveToken(input: string, cursorPosition: number) {
+  const tokenizedQuery = input.split(/[\s\n]/).reduce((acc, word, index) => {
     const previous = acc[index - 1];
     const start = index === 0 ? index : previous.range[1] + 1;
     const end = start + word.length;

--- a/examples/twitter-compose-with-typeahead/src/utils/isValidTwitterUsername.ts
+++ b/examples/twitter-compose-with-typeahead/src/utils/isValidTwitterUsername.ts
@@ -1,8 +1,3 @@
 export function isValidTwitterUsername(username: string) {
-  return (
-    username.startsWith('@') &&
-    username.length > 1 &&
-    username.length <= 15 &&
-    /^@\w+$/.test(username)
-  );
+  return /^@\w{1,15}$/.test(username);
 }


### PR DESCRIPTION
This refactors a few aspects of the Twitter example to reflect exactly the code from the [documentation guide](https://github.com/algolia/doc/pull/6240).

- Moved `defaultActiveItemId` inside the component
- Updated the name of the argument passed to `getActiveToken`
- Simplify Twitter username validation predicate with a better regular expression