### PR TITLE
fix(detached): open keyboard on input focus

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "packages/autocomplete-js/dist/umd/index.production.js",
-      "maxSize": "16.25 kB"
+      "maxSize": "16.5 kB"
     },
     {
       "path": "packages/autocomplete-preset-algolia/dist/umd/index.production.js",

--- a/packages/autocomplete-js/src/autocomplete.ts
+++ b/packages/autocomplete-js/src/autocomplete.ts
@@ -23,7 +23,7 @@ import {
   AutocompleteState,
 } from './types';
 import { userAgents } from './userAgents';
-import { mergeDeep, setProperties } from './utils';
+import { focusAndOpenKeyboard, mergeDeep, setProperties } from './utils';
 
 export function autocomplete<TItem extends BaseItem>(
   options: AutocompleteOptions<TItem>
@@ -351,32 +351,31 @@ export function autocomplete<TItem extends BaseItem>(
   }
 
   function setIsModalOpen(value: boolean) {
-    requestAnimationFrame(() => {
-      const prevValue = props.value.core.environment.document.body.contains(
+    const prevValue = props.value.core.environment.document.body.contains(
+      dom.value.detachedOverlay
+    );
+
+    if (value === prevValue) {
+      return;
+    }
+
+    if (value) {
+      props.value.core.environment.document.body.appendChild(
         dom.value.detachedOverlay
       );
+      props.value.core.environment.document.body.classList.add('aa-Detached');
 
-      if (value === prevValue) {
-        return;
-      }
-
-      if (value) {
-        props.value.core.environment.document.body.appendChild(
-          dom.value.detachedOverlay
-        );
-        props.value.core.environment.document.body.classList.add('aa-Detached');
-        dom.value.input.focus();
-      } else {
-        props.value.core.environment.document.body.removeChild(
-          dom.value.detachedOverlay
-        );
-        props.value.core.environment.document.body.classList.remove(
-          'aa-Detached'
-        );
-        autocomplete.value.setQuery('');
-        autocomplete.value.refresh();
-      }
-    });
+      focusAndOpenKeyboard(props.value.core.environment, dom.value.input);
+    } else {
+      props.value.core.environment.document.body.removeChild(
+        dom.value.detachedOverlay
+      );
+      props.value.core.environment.document.body.classList.remove(
+        'aa-Detached'
+      );
+      autocomplete.value.setQuery('');
+      autocomplete.value.refresh();
+    }
   }
 
   return {

--- a/packages/autocomplete-js/src/utils/focusAndOpenKeyboard.ts
+++ b/packages/autocomplete-js/src/utils/focusAndOpenKeyboard.ts
@@ -1,0 +1,30 @@
+import { AutocompleteEnvironment } from '@algolia/autocomplete-core';
+
+// Mobile devices don't open the keyboard when programmatically focusing inputs.
+// See https://stackoverflow.com/a/55425845
+export function focusAndOpenKeyboard(
+  environment: AutocompleteEnvironment,
+  inputElement: HTMLInputElement,
+  timeout: number = 0
+) {
+  if (inputElement) {
+    const tempInput = environment.document.createElement('input');
+    const { top, left } = inputElement.getBoundingClientRect();
+
+    tempInput.style.position = 'absolute';
+    tempInput.style.top = `${top}px`;
+    tempInput.style.left = `${left}px`;
+    tempInput.style.height = '0';
+    tempInput.style.opacity = '0';
+
+    environment.document.body.appendChild(tempInput);
+    tempInput.focus();
+
+    setTimeout(() => {
+      inputElement.focus();
+      inputElement.click();
+
+      environment.document.body.removeChild(tempInput);
+    }, timeout);
+  }
+}

--- a/packages/autocomplete-js/src/utils/index.ts
+++ b/packages/autocomplete-js/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './focusAndOpenKeyboard';
 export * from './getHTMLElement';
 export * from './mergeClassNames';
 export * from './mergeDeep';


### PR DESCRIPTION
This introduces a hack to **force the keyboard to open when opening the search modal in detached mode.**

## Summary

iPhones (and probably Android phones as well) don't let you programmatically assign focus, just like they don't allow you to autoplay videos, etc. We can set focus if this is done within a user event callback (which is the case here and it works) but we can't open the keyboard, this only happens when the user deliberately taps the input (we can't even simulate it).

Nike found a hacky workaround which was extracted in this [StackOverflow question](https://stackoverflow.com/questions/54424729/ios-show-keyboard-on-input-focus/55425845#55425845). I haven't found other workarounds.

Note that it doesn't work when called within `requestAnimationFrame`, which is why I had to remove it at least for the opening of the modal. Dropping this optimization is a trade-off, but since this isn't a DOM update that happens a lot (only when opening the modal) it's likely fine.

## Tests

Unfortunately I don't think there's a way to test this behavior for now. AFAIK the virtual keyboard isn't available in the browser, and [Cypress.io can't run tests on real mobiles](https://docs.cypress.io/faq/questions/general-questions-faq#Do-you-support-native-mobile-apps), so we can't even take screenshots with our current setup.

Investigating alternatives for end-to-end on mobile might be an option in the future, if we think it's worth it.

fix #653