### PR TITLE
chore(lerna): add `useWorkspaces` option

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,6 @@
 {
   "packages": ["packages/*", "examples/*"],
   "version": "1.5.0",
-  "npmClient": "yarn"
+  "npmClient": "yarn",
+  "useWorkspaces": true
 }


### PR DESCRIPTION
## Description

The [`useWorkspaces`](https://github.com/lerna/lerna/tree/main/commands/bootstrap#--use-workspaces) option enables better integration with Yarn Workspaces.

It is [required for Renovate](https://github.com/renovatebot/renovate/issues/7438#issuecomment-739755253) to use the `yarn` command instead of `lerna`.

## Related

- algolia/docsearch#1158
- algolia/react-instantsearch#3189