### PR TITLE
chore(lerna): rely on Yarn Workspaces

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,4 @@
 {
-  "packages": ["packages/*", "examples/*"],
   "version": "1.5.0",
   "npmClient": "yarn",
   "useWorkspaces": true


### PR DESCRIPTION
With the `useWorkspaces` option, Lerna relies on Yarn Workspaces defined in the root `package.json`.