### PR TITLE
docs(example): set up GitHub filters example with Algolia

### DIFF
--- a/examples/github-notification-filters/app.tsx
+++ b/examples/github-notification-filters/app.tsx
@@ -136,7 +136,7 @@ autocomplete<AutocompleteItem>({
 
         return tag.search({
           query: postfix,
-          facet: tag.token === 'org' && 'org',
+          facet: tag.token === 'org' ? 'org' : undefined,
           tags: tagsByToken[tag.token],
         });
       },

--- a/examples/github-notification-filters/app.tsx
+++ b/examples/github-notification-filters/app.tsx
@@ -144,8 +144,8 @@ autocomplete<AutocompleteItem>({
         header() {
           return <FilterHeader />;
         },
-        item({ item }) {
-          return <PostfixItem item={item} />;
+        item({ item, components }) {
+          return <PostfixItem item={item} components={components} />;
         },
       },
     };

--- a/examples/github-notification-filters/app.tsx
+++ b/examples/github-notification-filters/app.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
-import { h, render } from 'preact';
 import { autocomplete, AutocompleteSource } from '@algolia/autocomplete-js';
 import { createTagsPlugin, Tag } from '@algolia/autocomplete-plugin-tags';
+import { h, render } from 'preact';
 import qs from 'qs';
 
 import {

--- a/examples/github-notification-filters/components/PostfixItem.tsx
+++ b/examples/github-notification-filters/components/PostfixItem.tsx
@@ -1,20 +1,22 @@
 /** @jsx h */
+import { AutocompleteComponents } from '@algolia/autocomplete-js';
 import { h } from 'preact';
 
 import { AutocompleteItem } from '../types';
 
 type PostfixItemProps = {
   item: AutocompleteItem;
+  components: AutocompleteComponents;
 };
 
-export function PostfixItem({ item }: PostfixItemProps) {
+export function PostfixItem({ item, components }: PostfixItemProps) {
   return (
     <div className="aa-ItemWrapper">
       <div className="aa-ItemContent">
         <div className="aa-ItemContentBody">
           <div className="aa-ItemContentTitle">
             <strong>
-              {item.token}:{item.label}
+              {item.token}:<components.Highlight hit={item} attribute="label" />
             </strong>
           </div>
         </div>

--- a/examples/github-notification-filters/items.ts
+++ b/examples/github-notification-filters/items.ts
@@ -29,8 +29,6 @@ export const items = [
             query,
             params: {
               hitsPerPage: 10,
-              highlightPreTag: '<mark>',
-              highlightPostTag: '</mark>',
               filters: mapToAlgoliaNegativeFilters(tags, ['name']),
             },
           },
@@ -41,6 +39,10 @@ export const items = [
             token,
             label: hit.name,
             attribute,
+            _highlightResult: {
+              ...hit._highlightResult,
+              label: hit._highlightResult[attribute],
+            },
           }));
         },
       });
@@ -178,8 +180,6 @@ export const items = [
             query,
             params: {
               hitsPerPage: 10,
-              highlightPreTag: '<mark>',
-              highlightPostTag: '</mark>',
               filters: mapToAlgoliaNegativeFilters(tags, ['login']),
             },
           },
@@ -190,6 +190,10 @@ export const items = [
             token,
             label: hit.login,
             attribute,
+            _highlightResult: {
+              ...hit._highlightResult,
+              label: hit._highlightResult[attribute],
+            },
           }));
         },
       });

--- a/examples/github-notification-filters/items.ts
+++ b/examples/github-notification-filters/items.ts
@@ -7,7 +7,7 @@ import { Contributor, NotificationFilter, Repository } from './types';
 type SearchParams = {
   query?: string;
   facet?: string;
-  tags?: Tag<NotificationFilter>[];
+  tags?: Array<Tag<NotificationFilter>>;
 };
 
 export const items = [

--- a/examples/github-notification-filters/items.ts
+++ b/examples/github-notification-filters/items.ts
@@ -1,8 +1,5 @@
 import { Tag } from '@algolia/autocomplete-plugin-tags';
-import {
-  getAlgoliaResults,
-  getAlgoliaFacets,
-} from '@algolia/autocomplete-preset-algolia';
+import { getAlgoliaResults, getAlgoliaFacets } from '@algolia/autocomplete-js';
 
 import { searchClient } from './searchClient';
 import { Contributor, NotificationFilter, Repository } from './types';

--- a/examples/github-notification-filters/items.ts
+++ b/examples/github-notification-filters/items.ts
@@ -1,164 +1,243 @@
+import { Tag } from '@algolia/autocomplete-plugin-tags';
+import {
+  getAlgoliaResults,
+  getAlgoliaFacets,
+} from '@algolia/autocomplete-preset-algolia';
+
+import { searchClient } from './searchClient';
+import { Contributor, NotificationFilter, Repository } from './types';
+
+type SearchParams = {
+  query?: string;
+  facet?: string;
+  tags?: Tag<NotificationFilter>[];
+};
+
 export const items = [
   {
     token: 'repo',
     label: 'filter by repository',
-    postfixes: [
-      {
-        label: 'algolia/algoliasearch-client-javascript',
-      },
-      {
-        label: 'microsoft/TypeScript',
-      },
-      {
-        label: 'algolia/algoliasearch-helper-js',
-      },
-      {
-        label: 'algolia/autocomplete',
-      },
-      {
-        label: 'algolia/instantsearch.js',
-      },
-      {
-        label: 'algolia/docsearch',
-      },
-      {
-        label: 'algolia/docsearch-configs',
-      },
-    ],
+    attribute: 'name',
+    search({ query, tags = [] }: SearchParams) {
+      const { token, attribute } = this;
+
+      return getAlgoliaResults<Repository>({
+        searchClient,
+        queries: [
+          {
+            indexName: 'github_repos',
+            query,
+            params: {
+              hitsPerPage: 10,
+              highlightPreTag: '<mark>',
+              highlightPostTag: '</mark>',
+              filters: mapToAlgoliaNegativeFilters(tags, ['name']),
+            },
+          },
+        ],
+        transformResponse({ hits }) {
+          return hits[0].map((hit) => ({
+            ...hit,
+            token,
+            label: hit.name,
+            attribute,
+          }));
+        },
+      });
+    },
   },
   {
     token: 'is',
     label: 'filter by status or discussion type',
-    postfixes: [
-      {
-        label: 'read',
-      },
-      {
-        label: 'unread',
-      },
-      {
-        label: 'done',
-      },
-      {
-        label: 'check-suite',
-      },
-      {
-        label: 'commit',
-      },
-      {
-        label: 'gist',
-      },
-      {
-        label: 'release',
-      },
-      {
-        label: 'repository-invitation',
-      },
-      {
-        label: 'repository-vulnerability-alert',
-      },
-      {
-        label: 'repository-advisory',
-      },
-      {
-        label: 'team-discussion',
-      },
-      {
-        label: 'discussion',
-      },
-      {
-        label: 'issue-or-pull-request',
-      },
-    ],
+    search({ query, tags = [] }: SearchParams) {
+      const { token } = this;
+
+      return Promise.resolve(
+        [
+          {
+            label: 'read',
+          },
+          {
+            label: 'unread',
+          },
+          {
+            label: 'done',
+          },
+          {
+            label: 'check-suite',
+          },
+          {
+            label: 'commit',
+          },
+          {
+            label: 'gist',
+          },
+          {
+            label: 'release',
+          },
+          {
+            label: 'repository-invitation',
+          },
+          {
+            label: 'repository-vulnerability-alert',
+          },
+          {
+            label: 'repository-advisory',
+          },
+          {
+            label: 'team-discussion',
+          },
+          {
+            label: 'discussion',
+          },
+          {
+            label: 'issue-or-pull-request',
+          },
+        ]
+          .filter(
+            ({ label }) =>
+              label.startsWith(query) &&
+              !tags.some(({ value }) => value === label)
+          )
+          .map((item) => ({ ...item, token }))
+      );
+    },
   },
   {
     token: 'reason',
     label: 'filter by notification reason',
-    postfixes: [
-      {
-        label: 'assign',
-      },
-      {
-        label: 'author',
-      },
-      {
-        label: 'comment',
-      },
-      {
-        label: 'invitation',
-      },
-      {
-        label: 'manual',
-      },
-      {
-        label: 'mention',
-      },
-      {
-        label: 'review-requested',
-      },
-      {
-        label: 'security-advisory-credit',
-      },
-      {
-        label: 'security-alert',
-      },
-      {
-        label: 'state-change',
-      },
-      {
-        label: 'subscribed',
-      },
-      {
-        label: 'team-mention',
-      },
-      {
-        label: 'ci-activity',
-      },
-      {
-        label: 'approval-requested',
-      },
-    ],
+    search({ query, tags = [] }: SearchParams) {
+      const { token } = this;
+
+      return Promise.resolve(
+        [
+          {
+            label: 'assign',
+          },
+          {
+            label: 'author',
+          },
+          {
+            label: 'comment',
+          },
+          {
+            label: 'invitation',
+          },
+          {
+            label: 'manual',
+          },
+          {
+            label: 'mention',
+          },
+          {
+            label: 'review-requested',
+          },
+          {
+            label: 'security-advisory-credit',
+          },
+          {
+            label: 'security-alert',
+          },
+          {
+            label: 'state-change',
+          },
+          {
+            label: 'subscribed',
+          },
+          {
+            label: 'team-mention',
+          },
+          {
+            label: 'ci-activity',
+          },
+          {
+            label: 'approval-requested',
+          },
+        ]
+          .filter(
+            ({ label }) =>
+              label.startsWith(query) &&
+              !tags.some(({ value }) => value === label)
+          )
+          .map((item) => ({ ...item, token }))
+      );
+    },
   },
   {
     token: 'author',
     label: 'filter by notification author',
-    postfixes: [
-      {
-        label: 'sarahdayan',
-      },
-      {
-        label: 'renovate',
-      },
-      {
-        label: 'Haroenv',
-      },
-      {
-        label: 'dhayab',
-      },
-      {
-        label: 'francoischalifour',
-      },
-      {
-        label: 'shortcuts',
-      },
-      {
-        label: 'tkrugg',
-      },
-    ],
+    attribute: 'login',
+    search({ query, tags = [] }: SearchParams) {
+      const { token, attribute } = this;
+
+      return getAlgoliaResults<Contributor>({
+        searchClient,
+        queries: [
+          {
+            indexName: 'github_contributors',
+            query,
+            params: {
+              hitsPerPage: 10,
+              highlightPreTag: '<mark>',
+              highlightPostTag: '</mark>',
+              filters: mapToAlgoliaNegativeFilters(tags, ['login']),
+            },
+          },
+        ],
+        transformResponse({ hits }) {
+          return hits[0].map((hit) => ({
+            ...hit,
+            token,
+            label: hit.login,
+            attribute,
+          }));
+        },
+      });
+    },
   },
   {
     token: 'org',
     label: 'filter by organization',
-    postfixes: [
-      {
-        label: 'sarahdayan',
-      },
-      {
-        label: 'algolia',
-      },
-      {
-        label: 'codesandbox',
-      },
-    ],
+    attribute: 'label',
+    search({ query, facet, tags = [] }: SearchParams) {
+      const { token, attribute } = this;
+
+      return getAlgoliaFacets<Contributor>({
+        searchClient,
+        queries: [
+          {
+            indexName: 'github_contributors',
+            facet,
+            params: {
+              facetQuery: query,
+              maxFacetHits: 5,
+              filters: mapToAlgoliaNegativeFilters(tags, ['label']),
+            },
+          },
+        ],
+        transformResponse({ facetHits }) {
+          return facetHits[0].map((hit) => ({
+            ...hit,
+            token,
+            attribute,
+          }));
+        },
+      });
+    },
   },
 ];
+
+function mapToAlgoliaNegativeFilters(
+  tags: Array<Tag<NotificationFilter>>,
+  facetsToNegate: string[],
+  operator = 'AND'
+) {
+  return tags
+    .map(({ value, attribute }) => {
+      const filter = `${attribute}:"${value}"`;
+
+      return facetsToNegate.includes(attribute) && `NOT ${filter}`;
+    })
+    .filter(Boolean)
+    .join(` ${operator} `);
+}

--- a/examples/github-notification-filters/items.ts
+++ b/examples/github-notification-filters/items.ts
@@ -1,5 +1,5 @@
-import { Tag } from '@algolia/autocomplete-plugin-tags';
 import { getAlgoliaResults, getAlgoliaFacets } from '@algolia/autocomplete-js';
+import { Tag } from '@algolia/autocomplete-plugin-tags';
 
 import { searchClient } from './searchClient';
 import { Contributor, NotificationFilter, Repository } from './types';

--- a/examples/github-notification-filters/package.json
+++ b/examples/github-notification-filters/package.json
@@ -12,6 +12,7 @@
     "@algolia/autocomplete-js": "1.5.0",
     "@algolia/autocomplete-plugin-tags": "1.5.0",
     "@algolia/autocomplete-theme-classic": "1.5.0",
+    "algoliasearch": "4.9.1",
     "preact": "10.5.13",
     "qs": "6.10.1"
   },

--- a/examples/github-notification-filters/searchClient.ts
+++ b/examples/github-notification-filters/searchClient.ts
@@ -1,0 +1,6 @@
+import algoliasearch from 'algoliasearch';
+
+const appId = 'latency';
+const apiKey = '147a0e7dbc37d4c4dec9ec31b0f68716';
+
+export const searchClient = algoliasearch(appId, apiKey);

--- a/examples/github-notification-filters/style.css
+++ b/examples/github-notification-filters/style.css
@@ -33,6 +33,13 @@ body {
   margin-bottom: calc(var(--aa-spacing-half) * -1);
 }
 
+.aa-ItemContent .aa-ItemContentTitle mark {
+  background: rgba(
+    var(--aa-description-highlight-background-color-rgb),
+    var(--aa-description-highlight-background-color-alpha)
+  );
+}
+
 .aa-Tags {
   margin-right: 8px;
 }

--- a/examples/github-notification-filters/types/AutocompleteItem.ts
+++ b/examples/github-notification-filters/types/AutocompleteItem.ts
@@ -1,4 +1,5 @@
 export type AutocompleteItem = {
   token: string;
   label: string;
+  attribute: string;
 };

--- a/examples/github-notification-filters/types/Contributor.ts
+++ b/examples/github-notification-filters/types/Contributor.ts
@@ -1,0 +1,6 @@
+export type Contributor = {
+  login: string;
+  org: string;
+  avatar_url: string;
+  id: number;
+};

--- a/examples/github-notification-filters/types/NotificationFilter.ts
+++ b/examples/github-notification-filters/types/NotificationFilter.ts
@@ -1,4 +1,5 @@
 export type NotificationFilter = {
   token: string;
   value: string;
+  attribute: string;
 };

--- a/examples/github-notification-filters/types/Repository.ts
+++ b/examples/github-notification-filters/types/Repository.ts
@@ -1,0 +1,17 @@
+export type Repository = {
+  name: string;
+  description: string;
+  stargazers_count: number;
+  forks: number;
+  language: string;
+  owner: string;
+  topics: string[];
+  created_at: string;
+  default_branch: string;
+  homepage: string;
+  html_url: string;
+  id: number;
+  license: string;
+  open_issues: number;
+  watchers: number;
+};

--- a/examples/github-notification-filters/types/index.ts
+++ b/examples/github-notification-filters/types/index.ts
@@ -1,2 +1,4 @@
 export * from './AutocompleteItem';
+export * from './Contributor';
 export * from './NotificationFilter';
+export * from './Repository';


### PR DESCRIPTION
This swaps the static sources for repositories, authors and organizations with Algolia indices. This allows us to leverage Algolia features (full-text search, highlighting, custom ranking, search for facet values, etc.).

When a tag is selected, it's removed from the available filters to avoid adding the same tag twice and polluting the results.

https://user-images.githubusercontent.com/5370675/141218784-f8a45c3c-3b3e-4d9b-918b-4688258b373a.mov

The indices are static extracts from the GitHub public API, indexed in Algolia. They contain a list of public repos from Algolia and CodeSandbox, along with public members of both organizations.

[sandbox](http://codesandbox.io/s/github/algolia/autocomplete/tree/docs/github-filters-algolia/examples/github-notification-filters)