### PR TITLE
chore: add deprecation notice with redirection to new package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-> **Deprecation notice**
+> **⚠️ Deprecation notice**
 >
-> "Autocomplete.js" is deprecated. Please use "[@algolia/autocomplete-js](https://github.com/algolia/autocomplete#readme)" instead.
+> [Autocomplete.js (v0.x)](https://www.npmjs.com/package/autocomplete.js) is deprecated and no longer supported. Please use [Autocomplete](https://github.com/algolia/autocomplete#readme) instead.
+> To upgrade from v0.x, please follow our [upgrade guide](https://www.algolia.com/doc/ui-libraries/autocomplete/guides/upgrading/).
 
 # Autocomplete.js
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> **Deprecation notice**
+>
+> "Autocomplete.js" is deprecated. Please use "[@algolia/autocomplete-js](https://github.com/algolia/autocomplete#readme)" instead.
+
 # Autocomplete.js
 
 


### PR DESCRIPTION
This PR adds a mention in the README, asking developers to use `@algolia/instantsearch-js` instead.

Closes FX-548.