### PR TITLE
fix(concurrency): ensure panel stays closed after blur

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "packages/autocomplete-core/dist/umd/index.production.js",
-      "maxSize": "5.75 kB"
+      "maxSize": "6 kB"
     },
     {
       "path": "packages/autocomplete-js/dist/umd/index.production.js",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "packages/autocomplete-js/dist/umd/index.production.js",
-      "maxSize": "16.25 kB"
+      "maxSize": "16.5 kB"
     },
     {
       "path": "packages/autocomplete-preset-algolia/dist/umd/index.production.js",

--- a/packages/autocomplete-core/src/__tests__/concurrency.test.ts
+++ b/packages/autocomplete-core/src/__tests__/concurrency.test.ts
@@ -116,8 +116,7 @@ describe('concurrency', () => {
           getSources,
         });
 
-        userEvent.type(inputElement, 'a');
-        userEvent.type(inputElement, '{esc}');
+        userEvent.type(inputElement, 'a{esc}');
 
         await defer(() => {}, delay);
 
@@ -129,25 +128,26 @@ describe('concurrency', () => {
             }),
           })
         );
+        expect(getSources).toHaveBeenCalledTimes(1);
       });
 
       test('keeps the panel closed on blur', async () => {
         const onStateChange = jest.fn();
+        const getSources = jest.fn(() => {
+          return defer(() => {
+            return [
+              createSource({
+                getItems: () => [{ label: '1' }, { label: '2' }],
+              }),
+            ];
+          }, delay);
+        });
         const { inputElement } = createPlayground(createAutocomplete, {
           onStateChange,
-          getSources() {
-            return defer(() => {
-              return [
-                createSource({
-                  getItems: () => [{ label: '1' }, { label: '2' }],
-                }),
-              ];
-            }, delay);
-          },
+          getSources,
         });
 
-        userEvent.type(inputElement, 'a');
-        userEvent.type(inputElement, '{enter}');
+        userEvent.type(inputElement, 'a{enter}');
 
         await defer(() => {}, delay);
 
@@ -159,25 +159,27 @@ describe('concurrency', () => {
             }),
           })
         );
+        expect(getSources).toHaveBeenCalledTimes(1);
       });
 
       test('keeps the panel closed on touchstart blur', async () => {
         const onStateChange = jest.fn();
+        const getSources = jest.fn(() => {
+          return defer(() => {
+            return [
+              createSource({
+                getItems: () => [{ label: '1' }, { label: '2' }],
+              }),
+            ];
+          }, delay);
+        });
         const {
           getEnvironmentProps,
           inputElement,
           formElement,
         } = createPlayground(createAutocomplete, {
           onStateChange,
-          getSources() {
-            return defer(() => {
-              return [
-                createSource({
-                  getItems: () => [{ label: '1' }, { label: '2' }],
-                }),
-              ];
-            }, delay);
-          },
+          getSources,
         });
 
         const panelElement = document.createElement('div');
@@ -203,6 +205,7 @@ describe('concurrency', () => {
             }),
           })
         );
+        expect(getSources).toHaveBeenCalledTimes(1);
 
         window.removeEventListener('touchstart', onTouchStart);
       });
@@ -213,22 +216,22 @@ describe('concurrency', () => {
 
       test('keeps the panel closed on Escape', async () => {
         const onStateChange = jest.fn();
+        const getSources = jest.fn(() => {
+          return defer(() => {
+            return [
+              createSource({
+                getItems: () => [{ label: '1' }, { label: '2' }],
+              }),
+            ];
+          }, delay);
+        });
         const { inputElement } = createPlayground(createAutocomplete, {
           debug: true,
           onStateChange,
-          getSources() {
-            return defer(() => {
-              return [
-                createSource({
-                  getItems: () => [{ label: '1' }, { label: '2' }],
-                }),
-              ];
-            }, delay);
-          },
+          getSources,
         });
 
-        userEvent.type(inputElement, 'a');
-        userEvent.type(inputElement, '{esc}');
+        userEvent.type(inputElement, 'a{esc}');
 
         await defer(() => {}, delay);
 
@@ -240,26 +243,27 @@ describe('concurrency', () => {
             }),
           })
         );
+        expect(getSources).toHaveBeenCalledTimes(1);
       });
 
       test('keeps the panel open on blur', async () => {
         const onStateChange = jest.fn();
+        const getSources = jest.fn(() => {
+          return defer(() => {
+            return [
+              createSource({
+                getItems: () => [{ label: '1' }, { label: '2' }],
+              }),
+            ];
+          }, delay);
+        });
         const { inputElement } = createPlayground(createAutocomplete, {
           debug: true,
           onStateChange,
-          getSources() {
-            return defer(() => {
-              return [
-                createSource({
-                  getItems: () => [{ label: '1' }, { label: '2' }],
-                }),
-              ];
-            }, delay);
-          },
+          getSources,
         });
 
-        userEvent.type(inputElement, 'a');
-        userEvent.type(inputElement, '{enter}');
+        userEvent.type(inputElement, 'a{enter}');
 
         await defer(() => {}, delay);
 
@@ -271,10 +275,20 @@ describe('concurrency', () => {
             }),
           })
         );
+        expect(getSources).toHaveBeenCalledTimes(1);
       });
 
       test('keeps the panel open on touchstart blur', async () => {
         const onStateChange = jest.fn();
+        const getSources = jest.fn(() => {
+          return defer(() => {
+            return [
+              createSource({
+                getItems: () => [{ label: '1' }, { label: '2' }],
+              }),
+            ];
+          }, delay);
+        });
         const {
           getEnvironmentProps,
           inputElement,
@@ -282,15 +296,7 @@ describe('concurrency', () => {
         } = createPlayground(createAutocomplete, {
           debug: true,
           onStateChange,
-          getSources() {
-            return defer(() => {
-              return [
-                createSource({
-                  getItems: () => [{ label: '1' }, { label: '2' }],
-                }),
-              ];
-            }, delay);
-          },
+          getSources,
         });
 
         const panelElement = document.createElement('div');
@@ -316,6 +322,7 @@ describe('concurrency', () => {
             }),
           })
         );
+        expect(getSources).toHaveBeenCalledTimes(1);
 
         window.removeEventListener('touchstart', onTouchStart);
       });

--- a/packages/autocomplete-core/src/__tests__/concurrency.test.ts
+++ b/packages/autocomplete-core/src/__tests__/concurrency.test.ts
@@ -8,6 +8,10 @@ type Item = {
   label: string;
 };
 
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
 describe('concurrency', () => {
   test('resolves the responses in order from getSources', async () => {
     // These delays make the second query come back after the third one.
@@ -95,14 +99,10 @@ describe('concurrency', () => {
   describe('closing the panel with pending requests', () => {
     describe('without debug mode', () => {
       const delay = 300;
-      const onStateChange = jest.fn();
-      const {
-        getEnvironmentProps,
-        inputElement,
-        formElement,
-      } = createPlayground(createAutocomplete, {
-        onStateChange,
-        getSources() {
+
+      test('keeps the panel closed on Escape', async () => {
+        const onStateChange = jest.fn();
+        const getSources = jest.fn(() => {
           return defer(() => {
             return [
               createSource({
@@ -110,10 +110,12 @@ describe('concurrency', () => {
               }),
             ];
           }, delay);
-        },
-      });
+        });
+        const { inputElement } = createPlayground(createAutocomplete, {
+          onStateChange,
+          getSources,
+        });
 
-      test('keeps the panel closed on Escape', async () => {
         userEvent.type(inputElement, 'a');
         userEvent.type(inputElement, '{esc}');
 
@@ -130,6 +132,20 @@ describe('concurrency', () => {
       });
 
       test('keeps the panel closed on blur', async () => {
+        const onStateChange = jest.fn();
+        const { inputElement } = createPlayground(createAutocomplete, {
+          onStateChange,
+          getSources() {
+            return defer(() => {
+              return [
+                createSource({
+                  getItems: () => [{ label: '1' }, { label: '2' }],
+                }),
+              ];
+            }, delay);
+          },
+        });
+
         userEvent.type(inputElement, 'a');
         userEvent.type(inputElement, '{enter}');
 
@@ -146,6 +162,24 @@ describe('concurrency', () => {
       });
 
       test('keeps the panel closed on touchstart blur', async () => {
+        const onStateChange = jest.fn();
+        const {
+          getEnvironmentProps,
+          inputElement,
+          formElement,
+        } = createPlayground(createAutocomplete, {
+          onStateChange,
+          getSources() {
+            return defer(() => {
+              return [
+                createSource({
+                  getItems: () => [{ label: '1' }, { label: '2' }],
+                }),
+              ];
+            }, delay);
+          },
+        });
+
         const panelElement = document.createElement('div');
 
         const { onTouchStart } = getEnvironmentProps({
@@ -176,26 +210,23 @@ describe('concurrency', () => {
 
     describe('with debug mode', () => {
       const delay = 300;
-      const onStateChange = jest.fn();
-      const {
-        getEnvironmentProps,
-        inputElement,
-        formElement,
-      } = createPlayground(createAutocomplete, {
-        debug: true,
-        onStateChange,
-        getSources() {
-          return defer(() => {
-            return [
-              createSource({
-                getItems: () => [{ label: '1' }, { label: '2' }],
-              }),
-            ];
-          }, delay);
-        },
-      });
 
       test('keeps the panel closed on Escape', async () => {
+        const onStateChange = jest.fn();
+        const { inputElement } = createPlayground(createAutocomplete, {
+          debug: true,
+          onStateChange,
+          getSources() {
+            return defer(() => {
+              return [
+                createSource({
+                  getItems: () => [{ label: '1' }, { label: '2' }],
+                }),
+              ];
+            }, delay);
+          },
+        });
+
         userEvent.type(inputElement, 'a');
         userEvent.type(inputElement, '{esc}');
 
@@ -212,6 +243,21 @@ describe('concurrency', () => {
       });
 
       test('keeps the panel open on blur', async () => {
+        const onStateChange = jest.fn();
+        const { inputElement } = createPlayground(createAutocomplete, {
+          debug: true,
+          onStateChange,
+          getSources() {
+            return defer(() => {
+              return [
+                createSource({
+                  getItems: () => [{ label: '1' }, { label: '2' }],
+                }),
+              ];
+            }, delay);
+          },
+        });
+
         userEvent.type(inputElement, 'a');
         userEvent.type(inputElement, '{enter}');
 
@@ -228,6 +274,25 @@ describe('concurrency', () => {
       });
 
       test('keeps the panel open on touchstart blur', async () => {
+        const onStateChange = jest.fn();
+        const {
+          getEnvironmentProps,
+          inputElement,
+          formElement,
+        } = createPlayground(createAutocomplete, {
+          debug: true,
+          onStateChange,
+          getSources() {
+            return defer(() => {
+              return [
+                createSource({
+                  getItems: () => [{ label: '1' }, { label: '2' }],
+                }),
+              ];
+            }, delay);
+          },
+        });
+
         const panelElement = document.createElement('div');
 
         const { onTouchStart } = getEnvironmentProps({

--- a/packages/autocomplete-core/src/__tests__/getEnvironmentProps.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getEnvironmentProps.test.ts
@@ -30,7 +30,7 @@ describe('getEnvironmentProps', () => {
   });
 
   describe('onTouchStart', () => {
-    test('is a noop when panel is not open', () => {
+    test('is a noop when panel is not open and status is idle', () => {
       const onStateChange = jest.fn();
       const {
         getEnvironmentProps,

--- a/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getInputProps.test.ts
@@ -1894,7 +1894,7 @@ describe('getInputProps', () => {
   });
 
   describe('onBlur', () => {
-    test('resets activeItemId and isOpen', () => {
+    test('resets activeItemId and isOpen', async () => {
       const onStateChange = jest.fn();
       const { inputElement } = createPlayground(createAutocomplete, {
         onStateChange,
@@ -1904,6 +1904,8 @@ describe('getInputProps', () => {
 
       inputElement.focus();
       inputElement.blur();
+
+      await runAllMicroTasks();
 
       expect(onStateChange).toHaveBeenLastCalledWith(
         expect.objectContaining({

--- a/packages/autocomplete-core/src/__tests__/getSources.test.ts
+++ b/packages/autocomplete-core/src/__tests__/getSources.test.ts
@@ -8,6 +8,10 @@ import {
 import { createAutocomplete } from '../createAutocomplete';
 import * as handlers from '../onInput';
 
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
 describe('getSources', () => {
   test('gets calls on input', () => {
     const getSources = jest.fn((..._args: any[]) => {
@@ -140,7 +144,13 @@ describe('getSources', () => {
 
     const { inputElement } = createPlayground(createAutocomplete, {
       getSources() {
-        return [createSource({ sourceId: 'source1', getItems: () => {} })];
+        return [
+          createSource({
+            sourceId: 'source1',
+            // @ts-expect-error
+            getItems: () => {},
+          }),
+        ];
       },
     });
 

--- a/packages/autocomplete-core/src/createStore.ts
+++ b/packages/autocomplete-core/src/createStore.ts
@@ -35,5 +35,6 @@ export function createStore<TItem extends BaseItem>(
 
       onStoreStateChange({ state, prevState });
     },
+    shouldSkipSearch: false,
   };
 }

--- a/packages/autocomplete-core/src/createStore.ts
+++ b/packages/autocomplete-core/src/createStore.ts
@@ -35,6 +35,6 @@ export function createStore<TItem extends BaseItem>(
 
       onStoreStateChange({ state, prevState });
     },
-    shouldSkipSearch: false,
+    shouldSkipPendingUpdate: false,
   };
 }

--- a/packages/autocomplete-core/src/getPropGetters.ts
+++ b/packages/autocomplete-core/src/getPropGetters.ts
@@ -194,6 +194,16 @@ export function getPropGetters<
         if (!isTouchDevice) {
           store.dispatch('blur', null);
         }
+
+        onInput({
+          event: new Event('blur'),
+          props,
+          nextState: { isOpen: false, activeItemId: null },
+          query: store.getState().query,
+          refresh,
+          store,
+          ...setters,
+        });
       },
       onClick: (event) => {
         // When the panel is closed and you click on the input while

--- a/packages/autocomplete-core/src/getPropGetters.ts
+++ b/packages/autocomplete-core/src/getPropGetters.ts
@@ -64,7 +64,7 @@ export function getPropGetters<
           // We want to prevent any subsequent query from reopening the panel because
           // it would result it an unsolicited UI behavior.
           if (!props.debug && onInput.isRunning()) {
-            store.shouldSkipSearch = true;
+            store.shouldSkipPendingUpdate = true;
           }
         }
       },
@@ -209,7 +209,7 @@ export function getPropGetters<
           // could reopen the panel once they resolve.
           // We want to avoid any subsequent query and keep the panel closed.
           if (!props.debug && onInput.isRunning()) {
-            store.shouldSkipSearch = true;
+            store.shouldSkipPendingUpdate = true;
           }
         }
       },

--- a/packages/autocomplete-core/src/getPropGetters.ts
+++ b/packages/autocomplete-core/src/getPropGetters.ts
@@ -58,7 +58,7 @@ export function getPropGetters<
         if (isTargetWithinAutocomplete === false) {
           store.dispatch('blur', null);
 
-          if (!props.debug) {
+          if (!props.debug && onInput.isRunning()) {
             onInput({
               event: new Event('blur'),
               props,
@@ -208,7 +208,7 @@ export function getPropGetters<
         if (!isTouchDevice) {
           store.dispatch('blur', null);
 
-          if (!props.debug) {
+          if (!props.debug && onInput.isRunning()) {
             onInput({
               event: new Event('blur'),
               props,

--- a/packages/autocomplete-core/src/getPropGetters.ts
+++ b/packages/autocomplete-core/src/getPropGetters.ts
@@ -40,10 +40,8 @@ export function getPropGetters<
       // @TODO: support cases where there are multiple Autocomplete instances.
       // Right now, a second instance makes this computation return false.
       onTouchStart(event) {
-        const { isOpen, status, query } = store.getState();
-
         if (
-          (isOpen === false && status === 'idle') ||
+          (store.getState().isOpen === false && !onInput.isRunning()) ||
           event.target === inputElement
         ) {
           return;
@@ -63,7 +61,7 @@ export function getPropGetters<
               event: new Event('blur'),
               props,
               nextState: { isOpen: false, activeItemId: null },
-              query,
+              query: store.getState().query,
               refresh,
               store,
               ...setters,

--- a/packages/autocomplete-core/src/getPropGetters.ts
+++ b/packages/autocomplete-core/src/getPropGetters.ts
@@ -40,13 +40,16 @@ export function getPropGetters<
       // @TODO: support cases where there are multiple Autocomplete instances.
       // Right now, a second instance makes this computation return false.
       onTouchStart(event) {
-        if (
-          // If requests are still running when the user closes the panel, they
-          // could reopen the panel once they resolve.
-          // We want to avoid any subsequent query and keep the panel closed.
-          (store.getState().isOpen === false && !onInput.isRunning()) ||
-          event.target === inputElement
-        ) {
+        // The `onTouchStart` event shouldn't trigger the `blur` handler when
+        // it's not an interaction with Autocomplete. We detect it with the
+        // following heuristics:
+        // - the panel is closed AND there are no running requests
+        //   (no interaction with the autocomplete, no future state updates)
+        // - OR the touched target is the input element (should open the panel)
+        const isNotAutocompleteInteraction =
+          store.getState().isOpen === false && !onInput.isRunning();
+
+        if (isNotAutocompleteInteraction || event.target === inputElement) {
           return;
         }
 

--- a/packages/autocomplete-core/src/getPropGetters.ts
+++ b/packages/autocomplete-core/src/getPropGetters.ts
@@ -61,7 +61,8 @@ export function getPropGetters<
 
           // If requests are still running when the user closes the panel, they
           // could reopen the panel once they resolve.
-          // We want to avoid any subsequent query and keep the panel closed.
+          // We want to prevent any subsequent query from reopening the panel because
+          // it would result it an unsolicited UI behavior.
           if (!props.debug && onInput.isRunning()) {
             onInput({
               event: new Event('blur'),

--- a/packages/autocomplete-core/src/getPropGetters.ts
+++ b/packages/autocomplete-core/src/getPropGetters.ts
@@ -40,8 +40,10 @@ export function getPropGetters<
       // @TODO: support cases where there are multiple Autocomplete instances.
       // Right now, a second instance makes this computation return false.
       onTouchStart(event) {
+        const { isOpen, status, query } = store.getState();
+
         if (
-          store.getState().isOpen === false ||
+          (isOpen === false && status === 'idle') ||
           event.target === inputElement
         ) {
           return;
@@ -61,7 +63,7 @@ export function getPropGetters<
               event: new Event('blur'),
               props,
               nextState: { isOpen: false, activeItemId: null },
-              query: store.getState().query,
+              query,
               refresh,
               store,
               ...setters,

--- a/packages/autocomplete-core/src/getPropGetters.ts
+++ b/packages/autocomplete-core/src/getPropGetters.ts
@@ -55,6 +55,18 @@ export function getPropGetters<
 
         if (isTargetWithinAutocomplete === false) {
           store.dispatch('blur', null);
+
+          if (!props.debug) {
+            onInput({
+              event: new Event('blur'),
+              props,
+              nextState: { isOpen: false, activeItemId: null },
+              query: store.getState().query,
+              refresh,
+              store,
+              ...setters,
+            });
+          }
         }
       },
       // When scrolling on touch devices (mobiles, tablets, etc.), we want to
@@ -193,17 +205,19 @@ export function getPropGetters<
         // See explanation in `onTouchStart`.
         if (!isTouchDevice) {
           store.dispatch('blur', null);
-        }
 
-        onInput({
-          event: new Event('blur'),
-          props,
-          nextState: { isOpen: false, activeItemId: null },
-          query: store.getState().query,
-          refresh,
-          store,
-          ...setters,
-        });
+          if (!props.debug) {
+            onInput({
+              event: new Event('blur'),
+              props,
+              nextState: { isOpen: false, activeItemId: null },
+              query: store.getState().query,
+              refresh,
+              store,
+              ...setters,
+            });
+          }
+        }
       },
       onClick: (event) => {
         // When the panel is closed and you click on the input while

--- a/packages/autocomplete-core/src/getPropGetters.ts
+++ b/packages/autocomplete-core/src/getPropGetters.ts
@@ -41,6 +41,9 @@ export function getPropGetters<
       // Right now, a second instance makes this computation return false.
       onTouchStart(event) {
         if (
+          // If requests are still running when the user closes the panel, they
+          // could reopen the panel once they resolve.
+          // We want to avoid any subsequent query and keep the panel closed.
           (store.getState().isOpen === false && !onInput.isRunning()) ||
           event.target === inputElement
         ) {
@@ -56,6 +59,9 @@ export function getPropGetters<
         if (isTargetWithinAutocomplete === false) {
           store.dispatch('blur', null);
 
+          // If requests are still running when the user closes the panel, they
+          // could reopen the panel once they resolve.
+          // We want to avoid any subsequent query and keep the panel closed.
           if (!props.debug && onInput.isRunning()) {
             onInput({
               event: new Event('blur'),
@@ -206,6 +212,9 @@ export function getPropGetters<
         if (!isTouchDevice) {
           store.dispatch('blur', null);
 
+          // If requests are still running when the user closes the panel, they
+          // could reopen the panel once they resolve.
+          // We want to avoid any subsequent query and keep the panel closed.
           if (!props.debug && onInput.isRunning()) {
             onInput({
               event: new Event('blur'),

--- a/packages/autocomplete-core/src/getPropGetters.ts
+++ b/packages/autocomplete-core/src/getPropGetters.ts
@@ -64,15 +64,7 @@ export function getPropGetters<
           // We want to prevent any subsequent query from reopening the panel because
           // it would result it an unsolicited UI behavior.
           if (!props.debug && onInput.isRunning()) {
-            onInput({
-              event: new Event('blur'),
-              props,
-              nextState: { isOpen: false, activeItemId: null },
-              query: store.getState().query,
-              refresh,
-              store,
-              ...setters,
-            });
+            store.shouldSkipSearch = true;
           }
         }
       },
@@ -217,15 +209,7 @@ export function getPropGetters<
           // could reopen the panel once they resolve.
           // We want to avoid any subsequent query and keep the panel closed.
           if (!props.debug && onInput.isRunning()) {
-            onInput({
-              event: new Event('blur'),
-              props,
-              nextState: { isOpen: false, activeItemId: null },
-              query: store.getState().query,
-              refresh,
-              store,
-              ...setters,
-            });
+            store.shouldSkipSearch = true;
           }
         }
       },

--- a/packages/autocomplete-core/src/getPropGetters.ts
+++ b/packages/autocomplete-core/src/getPropGetters.ts
@@ -61,8 +61,8 @@ export function getPropGetters<
 
           // If requests are still running when the user closes the panel, they
           // could reopen the panel once they resolve.
-          // We want to prevent any subsequent query from reopening the panel because
-          // it would result it an unsolicited UI behavior.
+          // We want to prevent any subsequent query from reopening the panel
+          // because it would result in an unsolicited UI behavior.
           if (!props.debug && onInput.isRunning()) {
             store.shouldSkipPendingUpdate = true;
           }
@@ -207,7 +207,8 @@ export function getPropGetters<
 
           // If requests are still running when the user closes the panel, they
           // could reopen the panel once they resolve.
-          // We want to avoid any subsequent query and keep the panel closed.
+          // We want to prevent any subsequent query from reopening the panel
+          // because it would result in an unsolicited UI behavior.
           if (!props.debug && onInput.isRunning()) {
             store.shouldSkipPendingUpdate = true;
           }

--- a/packages/autocomplete-core/src/onInput.ts
+++ b/packages/autocomplete-core/src/onInput.ts
@@ -64,7 +64,7 @@ export function onInput<TItem extends BaseItem>({
 
   if (
     (!query && props.openOnFocus === false) ||
-    (nextState.isOpen === false && store.getState().status !== 'idle')
+    (nextState.isOpen === false && runConcurrentSafePromise.isRunning())
   ) {
     const collections = store.getState().collections.map((collection) => ({
       ...collection,

--- a/packages/autocomplete-core/src/onInput.ts
+++ b/packages/autocomplete-core/src/onInput.ts
@@ -29,6 +29,10 @@ interface OnInputParams<TItem extends BaseItem>
 
 const runConcurrentSafePromise = createConcurrentSafePromise();
 
+let nextStateRef: Partial<AutocompleteState<any>> = {};
+let propsRef = {} as InternalAutocompleteOptions<any>;
+let queryRef = '';
+
 export function onInput<TItem extends BaseItem>({
   event,
   nextState = {},
@@ -38,6 +42,10 @@ export function onInput<TItem extends BaseItem>({
   store,
   ...setters
 }: OnInputParams<TItem>): Promise<void> {
+  nextStateRef = nextState;
+  propsRef = props;
+  queryRef = query;
+
   if (lastStalledId) {
     props.environment.clearTimeout(lastStalledId);
   }
@@ -117,12 +125,12 @@ export function onInput<TItem extends BaseItem>({
     .then((collections) => {
       setStatus('idle');
       setCollections(collections as any);
-      const isPanelOpen = props.shouldPanelOpen({
+      const isPanelOpen = propsRef.shouldPanelOpen({
         state: store.getState(),
       });
       setIsOpen(
-        nextState.isOpen ??
-          ((props.openOnFocus && !query && isPanelOpen) || isPanelOpen)
+        nextStateRef.isOpen ??
+          ((propsRef.openOnFocus && !queryRef && isPanelOpen) || isPanelOpen)
       );
 
       const highlightedItem = getActiveItem(store.getState());
@@ -144,7 +152,7 @@ export function onInput<TItem extends BaseItem>({
     })
     .finally(() => {
       if (lastStalledId) {
-        props.environment.clearTimeout(lastStalledId);
+        propsRef.environment.clearTimeout(lastStalledId);
       }
     });
 }

--- a/packages/autocomplete-core/src/onInput.ts
+++ b/packages/autocomplete-core/src/onInput.ts
@@ -122,8 +122,8 @@ export function onInput<TItem extends BaseItem>({
 
       setStatus('idle');
 
-      if (store.shouldSkipSearch) {
-        store.shouldSkipSearch = false;
+      if (store.shouldSkipPendingUpdate) {
+        store.shouldSkipPendingUpdate = false;
 
         return;
       }

--- a/packages/autocomplete-core/src/onInput.ts
+++ b/packages/autocomplete-core/src/onInput.ts
@@ -30,6 +30,7 @@ interface OnInputParams<TItem extends BaseItem>
 const runConcurrentSafePromise = createConcurrentSafePromise();
 
 let nextStateRef: Partial<AutocompleteState<any>> = {};
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 let propsRef = {} as InternalAutocompleteOptions<any>;
 let queryRef = '';
 

--- a/packages/autocomplete-core/src/onInput.ts
+++ b/packages/autocomplete-core/src/onInput.ts
@@ -123,7 +123,9 @@ export function onInput<TItem extends BaseItem>({
       setStatus('idle');
 
       if (store.shouldSkipPendingUpdate) {
-        store.shouldSkipPendingUpdate = false;
+        if (!runConcurrentSafePromise.isRunning()) {
+          store.shouldSkipPendingUpdate = false;
+        }
 
         return;
       }

--- a/packages/autocomplete-core/src/onInput.ts
+++ b/packages/autocomplete-core/src/onInput.ts
@@ -131,6 +131,12 @@ export function onInput<TItem extends BaseItem>({
   )
     .then((collections) => {
       setStatus('idle');
+
+      if (store.shouldSkipSearch) {
+        store.shouldSkipSearch = false;
+        return;
+      }
+
       setCollections(collections as any);
       const isPanelOpen = lastProps.shouldPanelOpen({
         state: store.getState(),
@@ -139,10 +145,6 @@ export function onInput<TItem extends BaseItem>({
         lastNextState.isOpen ??
           ((lastProps.openOnFocus && !lastQuery && isPanelOpen) || isPanelOpen)
       );
-
-      if (lastNextState.activeItemId !== undefined) {
-        setActiveItemId(lastNextState.activeItemId);
-      }
 
       const highlightedItem = getActiveItem(store.getState());
 

--- a/packages/autocomplete-core/src/onInput.ts
+++ b/packages/autocomplete-core/src/onInput.ts
@@ -30,7 +30,8 @@ interface OnInputParams<TItem extends BaseItem>
 const runConcurrentSafePromise = createConcurrentSafePromise();
 
 // All three values are used in the `then` callback, but because callbacks can
-// execute in a different order than the call order, the values could be stale.
+// execute in a different order than the call order (e.g., on an unstable network),
+// the values could be stale.
 let lastNextState: Partial<AutocompleteState<any>> = {};
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 let lastProps = {} as InternalAutocompleteOptions<any>;

--- a/packages/autocomplete-core/src/onInput.ts
+++ b/packages/autocomplete-core/src/onInput.ts
@@ -118,6 +118,7 @@ export function onInput<TItem extends BaseItem>({
       // Parameters passed to `onInput` could be stale when the following code
       // executes, because `onInput` calls may not resolve in order.
       // If it becomes a problem we'll need to save the last passed parameters.
+      // See: https://codesandbox.io/s/agitated-cookies-y290z
 
       setStatus('idle');
 

--- a/packages/autocomplete-core/src/onInput.ts
+++ b/packages/autocomplete-core/src/onInput.ts
@@ -133,6 +133,10 @@ export function onInput<TItem extends BaseItem>({
           ((propsRef.openOnFocus && !queryRef && isPanelOpen) || isPanelOpen)
       );
 
+      if (nextStateRef.activeItemId !== undefined) {
+        setActiveItemId(nextStateRef.activeItemId);
+      }
+
       const highlightedItem = getActiveItem(store.getState());
 
       if (store.getState().activeItemId !== null && highlightedItem) {

--- a/packages/autocomplete-core/src/onInput.ts
+++ b/packages/autocomplete-core/src/onInput.ts
@@ -65,10 +65,7 @@ export function onInput<TItem extends BaseItem>({
   setQuery(query);
   setActiveItemId(props.defaultActiveItemId);
 
-  if (
-    (!query && props.openOnFocus === false) ||
-    (nextState.isOpen === false && runConcurrentSafePromise.isRunning())
-  ) {
+  if (!query && props.openOnFocus === false) {
     const collections = store.getState().collections.map((collection) => ({
       ...collection,
       items: [],

--- a/packages/autocomplete-core/src/onInput.ts
+++ b/packages/autocomplete-core/src/onInput.ts
@@ -29,6 +29,8 @@ interface OnInputParams<TItem extends BaseItem>
 
 const runConcurrentSafePromise = createConcurrentSafePromise();
 
+// All three values are used in the `then` callback, but because callbacks can
+// execute in a different order than the call order, the values could be stale.
 let lastNextState: Partial<AutocompleteState<any>> = {};
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 let lastProps = {} as InternalAutocompleteOptions<any>;

--- a/packages/autocomplete-core/src/onInput.ts
+++ b/packages/autocomplete-core/src/onInput.ts
@@ -164,3 +164,5 @@ export function onInput<TItem extends BaseItem>({
       }
     });
 }
+
+onInput.isRunning = runConcurrentSafePromise.isRunning;

--- a/packages/autocomplete-core/src/onInput.ts
+++ b/packages/autocomplete-core/src/onInput.ts
@@ -29,10 +29,10 @@ interface OnInputParams<TItem extends BaseItem>
 
 const runConcurrentSafePromise = createConcurrentSafePromise();
 
-let nextStateRef: Partial<AutocompleteState<any>> = {};
+let lastNextState: Partial<AutocompleteState<any>> = {};
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-let propsRef = {} as InternalAutocompleteOptions<any>;
-let queryRef = '';
+let lastProps = {} as InternalAutocompleteOptions<any>;
+let lastQuery = '';
 
 export function onInput<TItem extends BaseItem>({
   event,
@@ -43,9 +43,9 @@ export function onInput<TItem extends BaseItem>({
   store,
   ...setters
 }: OnInputParams<TItem>): Promise<void> {
-  nextStateRef = nextState;
-  propsRef = props;
-  queryRef = query;
+  lastNextState = nextState;
+  lastProps = props;
+  lastQuery = query;
 
   if (lastStalledId) {
     props.environment.clearTimeout(lastStalledId);
@@ -129,16 +129,16 @@ export function onInput<TItem extends BaseItem>({
     .then((collections) => {
       setStatus('idle');
       setCollections(collections as any);
-      const isPanelOpen = propsRef.shouldPanelOpen({
+      const isPanelOpen = lastProps.shouldPanelOpen({
         state: store.getState(),
       });
       setIsOpen(
-        nextStateRef.isOpen ??
-          ((propsRef.openOnFocus && !queryRef && isPanelOpen) || isPanelOpen)
+        lastNextState.isOpen ??
+          ((lastProps.openOnFocus && !lastQuery && isPanelOpen) || isPanelOpen)
       );
 
-      if (nextStateRef.activeItemId !== undefined) {
-        setActiveItemId(nextStateRef.activeItemId);
+      if (lastNextState.activeItemId !== undefined) {
+        setActiveItemId(lastNextState.activeItemId);
       }
 
       const highlightedItem = getActiveItem(store.getState());
@@ -160,7 +160,7 @@ export function onInput<TItem extends BaseItem>({
     })
     .finally(() => {
       if (lastStalledId) {
-        propsRef.environment.clearTimeout(lastStalledId);
+        lastProps.environment.clearTimeout(lastStalledId);
       }
     });
 }

--- a/packages/autocomplete-core/src/onInput.ts
+++ b/packages/autocomplete-core/src/onInput.ts
@@ -62,7 +62,10 @@ export function onInput<TItem extends BaseItem>({
   setQuery(query);
   setActiveItemId(props.defaultActiveItemId);
 
-  if (!query && props.openOnFocus === false) {
+  if (
+    (!query && props.openOnFocus === false) ||
+    (nextState.isOpen === false && store.getState().status !== 'idle')
+  ) {
     const collections = store.getState().collections.map((collection) => ({
       ...collection,
       items: [],

--- a/packages/autocomplete-core/src/onKeyDown.ts
+++ b/packages/autocomplete-core/src/onKeyDown.ts
@@ -98,7 +98,19 @@ export function onKeyDown<TItem extends BaseItem>({
     // panel.
     event.preventDefault();
 
+    const { query } = store.getState();
+
     store.dispatch(event.key, null);
+
+    onInput({
+      event: new Event('keydown'),
+      props,
+      nextState: { isOpen: false },
+      query,
+      refresh,
+      store,
+      ...setters,
+    });
   } else if (event.key === 'Enter') {
     // No active item, so we let the browser handle the native `onSubmit` form
     // event.

--- a/packages/autocomplete-core/src/onKeyDown.ts
+++ b/packages/autocomplete-core/src/onKeyDown.ts
@@ -100,6 +100,10 @@ export function onKeyDown<TItem extends BaseItem>({
 
     store.dispatch(event.key, null);
 
+    // Hitting the `Escape` key signals the end of a user interaction with the
+    // autocomplete. At this point, we should ignore any requests that are still
+    // running and could reopen the panel once they resolve, because that would
+    // result in an unsolicited UI behavior.
     if (onInput.isRunning()) {
       store.shouldSkipPendingUpdate = true;
     }

--- a/packages/autocomplete-core/src/onKeyDown.ts
+++ b/packages/autocomplete-core/src/onKeyDown.ts
@@ -98,20 +98,10 @@ export function onKeyDown<TItem extends BaseItem>({
     // panel.
     event.preventDefault();
 
-    const { query } = store.getState();
-
     store.dispatch(event.key, null);
 
     if (onInput.isRunning()) {
-      onInput({
-        event: new Event('keydown'),
-        props,
-        nextState: { isOpen: false },
-        query,
-        refresh,
-        store,
-        ...setters,
-      });
+      store.shouldSkipSearch = true;
     }
   } else if (event.key === 'Enter') {
     // No active item, so we let the browser handle the native `onSubmit` form

--- a/packages/autocomplete-core/src/onKeyDown.ts
+++ b/packages/autocomplete-core/src/onKeyDown.ts
@@ -101,7 +101,7 @@ export function onKeyDown<TItem extends BaseItem>({
     store.dispatch(event.key, null);
 
     if (onInput.isRunning()) {
-      store.shouldSkipSearch = true;
+      store.shouldSkipPendingUpdate = true;
     }
   } else if (event.key === 'Enter') {
     // No active item, so we let the browser handle the native `onSubmit` form

--- a/packages/autocomplete-core/src/onKeyDown.ts
+++ b/packages/autocomplete-core/src/onKeyDown.ts
@@ -102,15 +102,17 @@ export function onKeyDown<TItem extends BaseItem>({
 
     store.dispatch(event.key, null);
 
-    onInput({
-      event: new Event('keydown'),
-      props,
-      nextState: { isOpen: false },
-      query,
-      refresh,
-      store,
-      ...setters,
-    });
+    if (onInput.isRunning()) {
+      onInput({
+        event: new Event('keydown'),
+        props,
+        nextState: { isOpen: false },
+        query,
+        refresh,
+        store,
+        ...setters,
+      });
+    }
   } else if (event.key === 'Enter') {
     // No active item, so we let the browser handle the native `onSubmit` form
     // event.

--- a/packages/autocomplete-core/src/types/AutocompleteStore.ts
+++ b/packages/autocomplete-core/src/types/AutocompleteStore.ts
@@ -5,7 +5,7 @@ import { AutocompleteState } from './AutocompleteState';
 export interface AutocompleteStore<TItem extends BaseItem> {
   getState(): AutocompleteState<TItem>;
   dispatch(action: ActionType, payload: any): void;
-  shouldSkipSearch: boolean;
+  shouldSkipPendingUpdate: boolean;
 }
 
 export type Reducer = <TItem extends BaseItem>(

--- a/packages/autocomplete-core/src/types/AutocompleteStore.ts
+++ b/packages/autocomplete-core/src/types/AutocompleteStore.ts
@@ -5,6 +5,7 @@ import { AutocompleteState } from './AutocompleteState';
 export interface AutocompleteStore<TItem extends BaseItem> {
   getState(): AutocompleteState<TItem>;
   dispatch(action: ActionType, payload: any): void;
+  shouldSkipSearch: boolean;
 }
 
 export type Reducer = <TItem extends BaseItem>(

--- a/packages/autocomplete-core/src/utils/__tests__/createConcurrentSafePromise.test.ts
+++ b/packages/autocomplete-core/src/utils/__tests__/createConcurrentSafePromise.test.ts
@@ -3,9 +3,7 @@ import { createConcurrentSafePromise } from '../createConcurrentSafePromise';
 
 describe('createConcurrentSafePromise', () => {
   test('resolves the non-promise values in order', async () => {
-    type PromiseValue = { value: number };
-
-    const runConcurrentSafePromise = createConcurrentSafePromise<PromiseValue>();
+    const runConcurrentSafePromise = createConcurrentSafePromise();
     const concurrentSafePromise1 = runConcurrentSafePromise({ value: 1 });
     const concurrentSafePromise2 = runConcurrentSafePromise({ value: 2 });
     const concurrentSafePromise3 = runConcurrentSafePromise({ value: 3 });
@@ -18,9 +16,7 @@ describe('createConcurrentSafePromise', () => {
   });
 
   test('resolves the values in order when sequenced', async () => {
-    type PromiseValue = { value: number };
-
-    const runConcurrentSafePromise = createConcurrentSafePromise<PromiseValue>();
+    const runConcurrentSafePromise = createConcurrentSafePromise();
     const concurrentSafePromise1 = runConcurrentSafePromise(
       defer(() => ({ value: 1 }), 100)
     );
@@ -39,9 +35,7 @@ describe('createConcurrentSafePromise', () => {
   });
 
   test('resolves the value from the last call', async () => {
-    type PromiseValue = { value: number };
-
-    const runConcurrentSafePromise = createConcurrentSafePromise<PromiseValue>();
+    const runConcurrentSafePromise = createConcurrentSafePromise();
     const concurrentSafePromise1 = runConcurrentSafePromise(
       defer(() => ({ value: 1 }), 100)
     );
@@ -60,5 +54,43 @@ describe('createConcurrentSafePromise', () => {
     // is returned.
     expect(await concurrentSafePromise2).toEqual({ value: 3 });
     expect(await concurrentSafePromise3).toEqual({ value: 3 });
+  });
+
+  test('returns whether promises are currently running', async () => {
+    const runConcurrentSafePromise = createConcurrentSafePromise();
+    const concurrentSafePromise1 = runConcurrentSafePromise(
+      defer(() => ({ value: 1 }), 0)
+    );
+    const concurrentSafePromise2 = runConcurrentSafePromise(
+      defer(() => ({ value: 2 }), 0)
+    );
+    const concurrentSafePromise3 = runConcurrentSafePromise(
+      defer(() => ({ value: 3 }), 0)
+    );
+
+    jest.runAllTimers();
+
+    expect(runConcurrentSafePromise.isRunning()).toBe(true);
+
+    await concurrentSafePromise1;
+    await concurrentSafePromise2;
+
+    expect(runConcurrentSafePromise.isRunning()).toBe(true);
+
+    await concurrentSafePromise3;
+
+    expect(runConcurrentSafePromise.isRunning()).toBe(false);
+
+    const concurrentSafePromise4 = runConcurrentSafePromise(
+      defer(() => Promise.reject(), 400)
+    );
+
+    expect(runConcurrentSafePromise.isRunning()).toBe(true);
+
+    try {
+      await concurrentSafePromise4;
+    } catch (err) {}
+
+    expect(runConcurrentSafePromise.isRunning()).toBe(false);
   });
 });

--- a/packages/autocomplete-core/src/utils/__tests__/createConcurrentSafePromise.test.ts
+++ b/packages/autocomplete-core/src/utils/__tests__/createConcurrentSafePromise.test.ts
@@ -1,3 +1,5 @@
+import { noop } from '@algolia/autocomplete-shared';
+
 import { defer } from '../../../../../test/utils';
 import { createConcurrentSafePromise } from '../createConcurrentSafePromise';
 
@@ -82,14 +84,16 @@ describe('createConcurrentSafePromise', () => {
     expect(runConcurrentSafePromise.isRunning()).toBe(false);
 
     const concurrentSafePromise4 = runConcurrentSafePromise(
-      defer(() => Promise.reject(), 400)
+      defer(() => Promise.reject(new Error()), 400)
     );
 
     expect(runConcurrentSafePromise.isRunning()).toBe(true);
 
     try {
       await concurrentSafePromise4;
-    } catch (err) {}
+    } catch (err) {
+      noop();
+    }
 
     expect(runConcurrentSafePromise.isRunning()).toBe(false);
   });

--- a/packages/autocomplete-core/src/utils/__tests__/createConcurrentSafePromise.test.ts
+++ b/packages/autocomplete-core/src/utils/__tests__/createConcurrentSafePromise.test.ts
@@ -1,5 +1,3 @@
-import { noop } from '@algolia/autocomplete-shared';
-
 import { defer } from '../../../../../test/utils';
 import { createConcurrentSafePromise } from '../createConcurrentSafePromise';
 
@@ -91,9 +89,8 @@ describe('createConcurrentSafePromise', () => {
 
     try {
       await concurrentSafePromise4;
-    } catch (err) {
-      noop();
-    }
+      // eslint-disable-next-line no-empty
+    } catch (err) {}
 
     expect(runConcurrentSafePromise.isRunning()).toBe(false);
   });

--- a/packages/autocomplete-core/src/utils/createConcurrentSafePromise.ts
+++ b/packages/autocomplete-core/src/utils/createConcurrentSafePromise.ts
@@ -10,37 +10,41 @@ export function createConcurrentSafePromise() {
   let basePromiseId = -1;
   let latestResolvedId = -1;
   let latestResolvedValue: unknown = undefined;
+  let runningPromises = 0;
 
   function runConcurrentSafePromise<TValue>(promise: MaybePromise<TValue>) {
     basePromiseId++;
+    runningPromises++;
     const currentPromiseId = basePromiseId;
 
-    return Promise.resolve(promise).then((x) => {
-      // The promise might take too long to resolve and get outdated. This would
-      // result in resolving stale values.
-      // When this happens, we ignore the promise value and return the one
-      // coming from the latest resolved value.
-      //
-      // +----------------------------------+
-      // |        100ms                     |
-      // | run(1) +--->  R1                 |
-      // |        300ms                     |
-      // | run(2) +-------------> R2 (SKIP) |
-      // |        200ms                     |
-      // | run(3) +--------> R3             |
-      // +----------------------------------+
-      if (latestResolvedValue && currentPromiseId < latestResolvedId) {
-        return latestResolvedValue as TValue;
-      }
+    return Promise.resolve(promise)
+      .then((x) => {
+        // The promise might take too long to resolve and get outdated. This would
+        // result in resolving stale values.
+        // When this happens, we ignore the promise value and return the one
+        // coming from the latest resolved value.
+        //
+        // +----------------------------------+
+        // |        100ms                     |
+        // | run(1) +--->  R1                 |
+        // |        300ms                     |
+        // | run(2) +-------------> R2 (SKIP) |
+        // |        200ms                     |
+        // | run(3) +--------> R3             |
+        // +----------------------------------+
+        if (latestResolvedValue && currentPromiseId < latestResolvedId) {
+          return latestResolvedValue as TValue;
+        }
 
-      latestResolvedId = currentPromiseId;
-      latestResolvedValue = x;
+        latestResolvedId = currentPromiseId;
+        latestResolvedValue = x;
 
-      return x;
-    });
+        return x;
+      })
+      .finally(() => runningPromises--);
   }
 
-  runConcurrentSafePromise.isRunning = () => basePromiseId !== latestResolvedId;
+  runConcurrentSafePromise.isRunning = () => runningPromises > 0;
 
   return runConcurrentSafePromise;
 }

--- a/packages/autocomplete-core/src/utils/createConcurrentSafePromise.ts
+++ b/packages/autocomplete-core/src/utils/createConcurrentSafePromise.ts
@@ -11,9 +11,7 @@ export function createConcurrentSafePromise() {
   let latestResolvedId = -1;
   let latestResolvedValue: unknown = undefined;
 
-  return function runConcurrentSafePromise<TValue>(
-    promise: MaybePromise<TValue>
-  ) {
+  function runConcurrentSafePromise<TValue>(promise: MaybePromise<TValue>) {
     basePromiseId++;
     const currentPromiseId = basePromiseId;
 
@@ -40,5 +38,9 @@ export function createConcurrentSafePromise() {
 
       return x;
     });
-  };
+  }
+
+  runConcurrentSafePromise.isRunning = () => basePromiseId !== latestResolvedId;
+
+  return runConcurrentSafePromise;
 }

--- a/packages/autocomplete-core/src/utils/createConcurrentSafePromise.ts
+++ b/packages/autocomplete-core/src/utils/createConcurrentSafePromise.ts
@@ -10,11 +10,11 @@ export function createConcurrentSafePromise() {
   let basePromiseId = -1;
   let latestResolvedId = -1;
   let latestResolvedValue: unknown = undefined;
-  let runningPromises = 0;
+  let runningPromisesCount = 0;
 
   function runConcurrentSafePromise<TValue>(promise: MaybePromise<TValue>) {
     basePromiseId++;
-    runningPromises++;
+    runningPromisesCount++;
     const currentPromiseId = basePromiseId;
 
     return Promise.resolve(promise)
@@ -41,10 +41,10 @@ export function createConcurrentSafePromise() {
 
         return x;
       })
-      .finally(() => runningPromises--);
+      .finally(() => runningPromisesCount--);
   }
 
-  runConcurrentSafePromise.isRunning = () => runningPromises > 0;
+  runConcurrentSafePromise.isRunning = () => runningPromisesCount > 0;
 
   return runConcurrentSafePromise;
 }


### PR DESCRIPTION
This fixes a concurrency issue with closing the panel by running an additional tracked promise without triggering a search.

## Problem

When a user types a query that triggers network requests (for example, to Algolia), these requests could sometimes take longer to resolve (e.g., the service is slow, the network is slow). In the meantime, the user could decide to manually close the panel. However, a late resolving request could reopen the panel.

This doesn't make sense from a functional perspective: if you've purposefully closed the panel, it should be considered a cancellation.

The issue comes from late promises in `onInput` performing asynchronous state updates that cancel previous ones. This is a similar problem to #654.

## Solution

Since we can't avoid asynchronous and potentially late state updates, we can schedule another one when we close the panel by calling `onInput` with `{ nextState: isOpen: false }`. When a user closes the panel, it creates a new concurrent-safe promise that will follow any running ones and close the panel.

To avoid triggering an extra request when we do this, we make sure to return early (before calling `getSources`) in those situations.

This PR introduces a new `isRunning` private method on the function returned from `createConcurrentSafePromise` to know whether there are running promises. This is useful to control when we need to skip a search, or when to schedule the extra `onInput` call.

https://user-images.githubusercontent.com/5370675/143658311-c5410630-f28d-40b9-a276-ff586aef90f0.mov

I've left a couple inline review comments to explain some implementation details.

## Next steps

No major new concept is introduced to fix this issue, but using `onInput` to schedule a later state update is a workaround. In the future, if we need to do this elsewhere, we might want to introduce a generic helper to do it (e.g., `onAsyncUpdate(maybePromise, nextState)`).

fix #806