### PR TITLE
chore(examples): update search client to v5

### DIFF
--- a/examples/github-notification-filters/package.json
+++ b/examples/github-notification-filters/package.json
@@ -12,7 +12,7 @@
     "@algolia/autocomplete-js": "1.17.2",
     "@algolia/autocomplete-plugin-tags": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "preact": "10.13.2",
     "qs": "6.11.1"
   },

--- a/examples/github-notification-filters/searchClient.ts
+++ b/examples/github-notification-filters/searchClient.ts
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 
 const appId = 'latency';
 const apiKey = '147a0e7dbc37d4c4dec9ec31b0f68716';

--- a/examples/html-templates/app.js
+++ b/examples/html-templates/app.js
@@ -1,5 +1,5 @@
 import { autocomplete, getAlgoliaResults } from '@algolia/autocomplete-js';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 
 import '@algolia/autocomplete-theme-classic';
 

--- a/examples/html-templates/package.json
+++ b/examples/html-templates/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@algolia/autocomplete-js": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
-    "algoliasearch": "4.16.0"
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8"
   },
   "devDependencies": {
     "@algolia/client-search": "4.16.0",

--- a/examples/instantsearch/package.json
+++ b/examples/instantsearch/package.json
@@ -14,7 +14,7 @@
     "@algolia/autocomplete-plugin-recent-searches": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
     "@algolia/client-search": "4.16.0",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "instantsearch.js": "4.53.0"
   },
   "devDependencies": {

--- a/examples/instantsearch/src/searchClient.ts
+++ b/examples/instantsearch/src/searchClient.ts
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 
 export const searchClient = algoliasearch(
   'latency',

--- a/examples/multiple-datasets-with-headers/app.tsx
+++ b/examples/multiple-datasets-with-headers/app.tsx
@@ -3,7 +3,7 @@
 import { autocomplete } from '@algolia/autocomplete-js';
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
 import { createLocalStorageRecentSearchesPlugin } from '@algolia/autocomplete-plugin-recent-searches';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 import { h, Fragment } from 'preact';
 
 import '@algolia/autocomplete-theme-classic';

--- a/examples/multiple-datasets-with-headers/categoriesPlugin.tsx
+++ b/examples/multiple-datasets-with-headers/categoriesPlugin.tsx
@@ -1,7 +1,7 @@
 /** @jsxRuntime classic */
 /** @jsx h */
 import { AutocompletePlugin, getAlgoliaFacets } from '@algolia/autocomplete-js';
-import { SearchClient } from 'algoliasearch/lite';
+import type { SearchClient } from 'algoliasearch-v5';
 import { h, Fragment } from 'preact';
 
 type CategoryItem = {

--- a/examples/multiple-datasets-with-headers/package.json
+++ b/examples/multiple-datasets-with-headers/package.json
@@ -13,7 +13,7 @@
     "@algolia/autocomplete-plugin-query-suggestions": "1.17.2",
     "@algolia/autocomplete-plugin-recent-searches": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "preact": "10.13.2"
   },
   "devDependencies": {

--- a/examples/panel-placement/app.tsx
+++ b/examples/panel-placement/app.tsx
@@ -8,7 +8,7 @@ import {
   GetSources,
 } from '@algolia/autocomplete-js';
 import { Hit } from '@algolia/client-search';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 import { h } from 'preact';
 
 import '@algolia/autocomplete-theme-classic';

--- a/examples/panel-placement/package.json
+++ b/examples/panel-placement/package.json
@@ -12,7 +12,7 @@
     "@algolia/autocomplete-core": "1.17.2",
     "@algolia/autocomplete-js": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "preact": "10.13.2"
   },
   "devDependencies": {

--- a/examples/playground/app.tsx
+++ b/examples/playground/app.tsx
@@ -8,7 +8,7 @@ import {
 } from '@algolia/autocomplete-js';
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
 import { createLocalStorageRecentSearchesPlugin } from '@algolia/autocomplete-plugin-recent-searches';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 import { h, Fragment } from 'preact';
 
 import '@algolia/autocomplete-theme-classic';

--- a/examples/playground/categoriesPlugin.tsx
+++ b/examples/playground/categoriesPlugin.tsx
@@ -1,7 +1,7 @@
 /** @jsxRuntime classic */
 /** @jsx h */
 import { AutocompletePlugin, getAlgoliaFacets } from '@algolia/autocomplete-js';
-import { SearchClient } from 'algoliasearch/lite';
+import type { SearchClient } from 'algoliasearch-v5';
 import { h, Fragment } from 'preact';
 
 type CategoryRecord = {

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -15,7 +15,7 @@
     "@algolia/autocomplete-preset-algolia": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
     "@algolia/client-search": "4.16.0",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "preact": "10.13.2",
     "search-insights": "2.13.0"
   },

--- a/examples/preview-panel-in-modal/app.tsx
+++ b/examples/preview-panel-in-modal/app.tsx
@@ -1,7 +1,7 @@
 /** @jsxRuntime classic */
 /** @jsx h */
 import { autocomplete, getAlgoliaResults } from '@algolia/autocomplete-js';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 import { h, render } from 'preact';
 
 import '@algolia/autocomplete-theme-classic';

--- a/examples/preview-panel-in-modal/package.json
+++ b/examples/preview-panel-in-modal/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@algolia/autocomplete-js": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "preact": "10.13.2",
     "qs": "6.11.1"
   },

--- a/examples/query-suggestions-with-categories/app.tsx
+++ b/examples/query-suggestions-with-categories/app.tsx
@@ -1,6 +1,6 @@
 import { autocomplete } from '@algolia/autocomplete-js';
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 
 import '@algolia/autocomplete-theme-classic';
 

--- a/examples/query-suggestions-with-categories/package.json
+++ b/examples/query-suggestions-with-categories/package.json
@@ -12,7 +12,7 @@
     "@algolia/autocomplete-js": "1.17.2",
     "@algolia/autocomplete-plugin-query-suggestions": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "preact": "10.13.2"
   },
   "devDependencies": {

--- a/examples/query-suggestions-with-hits/app.tsx
+++ b/examples/query-suggestions-with-hits/app.tsx
@@ -7,7 +7,7 @@ import {
   AutocompleteInsightsApi,
 } from '@algolia/autocomplete-js';
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 import { h, Fragment } from 'preact';
 
 import '@algolia/autocomplete-theme-classic';

--- a/examples/query-suggestions-with-hits/package.json
+++ b/examples/query-suggestions-with-hits/package.json
@@ -15,7 +15,7 @@
     "@algolia/autocomplete-preset-algolia": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
     "@algolia/client-search": "4.16.0",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "preact": "10.13.2",
     "search-insights": "2.13.0"
   },

--- a/examples/query-suggestions-with-inline-categories/app.tsx
+++ b/examples/query-suggestions-with-inline-categories/app.tsx
@@ -2,7 +2,7 @@
 /** @jsx h */
 import { autocomplete } from '@algolia/autocomplete-js';
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 import { h } from 'preact';
 
 import '@algolia/autocomplete-theme-classic';

--- a/examples/query-suggestions-with-inline-categories/package.json
+++ b/examples/query-suggestions-with-inline-categories/package.json
@@ -12,7 +12,7 @@
     "@algolia/autocomplete-js": "1.17.2",
     "@algolia/autocomplete-plugin-query-suggestions": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "preact": "10.13.2"
   },
   "devDependencies": {

--- a/examples/query-suggestions-with-recent-searches-and-categories/app.tsx
+++ b/examples/query-suggestions-with-recent-searches-and-categories/app.tsx
@@ -1,7 +1,7 @@
 import { autocomplete } from '@algolia/autocomplete-js';
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
 import { createLocalStorageRecentSearchesPlugin } from '@algolia/autocomplete-plugin-recent-searches';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 
 import '@algolia/autocomplete-theme-classic';
 

--- a/examples/query-suggestions-with-recent-searches-and-categories/package.json
+++ b/examples/query-suggestions-with-recent-searches-and-categories/package.json
@@ -14,7 +14,7 @@
     "@algolia/autocomplete-plugin-recent-searches": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
     "@algolia/client-search": "4.16.0",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "preact": "10.13.2"
   },
   "devDependencies": {

--- a/examples/query-suggestions-with-recent-searches/app.tsx
+++ b/examples/query-suggestions-with-recent-searches/app.tsx
@@ -3,7 +3,7 @@
 import { autocomplete } from '@algolia/autocomplete-js';
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
 import { createLocalStorageRecentSearchesPlugin } from '@algolia/autocomplete-plugin-recent-searches';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 import { h, Fragment } from 'preact';
 
 import '@algolia/autocomplete-theme-classic';

--- a/examples/query-suggestions-with-recent-searches/package.json
+++ b/examples/query-suggestions-with-recent-searches/package.json
@@ -13,7 +13,7 @@
     "@algolia/autocomplete-plugin-query-suggestions": "1.17.2",
     "@algolia/autocomplete-plugin-recent-searches": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "preact": "10.13.2"
   },
   "devDependencies": {

--- a/examples/query-suggestions/app.tsx
+++ b/examples/query-suggestions/app.tsx
@@ -1,6 +1,6 @@
 import { autocomplete } from '@algolia/autocomplete-js';
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 
 import '@algolia/autocomplete-theme-classic';
 

--- a/examples/query-suggestions/package.json
+++ b/examples/query-suggestions/package.json
@@ -12,7 +12,7 @@
     "@algolia/autocomplete-js": "1.17.2",
     "@algolia/autocomplete-plugin-query-suggestions": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "preact": "10.13.2"
   },
   "devDependencies": {

--- a/examples/react-17/package.json
+++ b/examples/react-17/package.json
@@ -13,7 +13,7 @@
     "@algolia/autocomplete-core": "1.17.2",
     "@algolia/autocomplete-preset-algolia": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "react": "17.0.2",
     "react-dom": "17.0.2"
   },

--- a/examples/react-17/src/Autocomplete.tsx
+++ b/examples/react-17/src/Autocomplete.tsx
@@ -5,7 +5,7 @@ import {
 } from '@algolia/autocomplete-core';
 import { getAlgoliaResults } from '@algolia/autocomplete-preset-algolia';
 import { Hit } from '@algolia/client-search';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 import React from 'react';
 
 import { ClearIcon } from './ClearIcon';

--- a/examples/react-instantsearch/package.json
+++ b/examples/react-instantsearch/package.json
@@ -14,7 +14,7 @@
     "@algolia/autocomplete-plugin-query-suggestions": "1.17.2",
     "@algolia/autocomplete-plugin-recent-searches": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-instantsearch": "7.11.3"

--- a/examples/react-instantsearch/src/App.tsx
+++ b/examples/react-instantsearch/src/App.tsx
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 import {
   Configure,
   HierarchicalMenu,

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@algolia/autocomplete-js": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, createElement, Fragment } from 'react';
 import { createRoot } from 'react-dom/client';
 import { autocomplete, getAlgoliaResults } from '@algolia/autocomplete-js';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 
 import type { AutocompleteComponents } from '@algolia/autocomplete-js';
 import type { Hit } from '@algolia/client-search';

--- a/examples/recently-viewed-items/app.tsx
+++ b/examples/recently-viewed-items/app.tsx
@@ -5,7 +5,7 @@ import {
   AutocompleteComponents,
   getAlgoliaResults,
 } from '@algolia/autocomplete-js';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 import { h, Fragment } from 'preact';
 
 import '@algolia/autocomplete-theme-classic';

--- a/examples/recently-viewed-items/package.json
+++ b/examples/recently-viewed-items/package.json
@@ -13,7 +13,7 @@
     "@algolia/autocomplete-plugin-recent-searches": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
     "@algolia/client-search": "4.16.0",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "preact": "10.13.2"
   },
   "devDependencies": {

--- a/examples/redirect-url/app.tsx
+++ b/examples/redirect-url/app.tsx
@@ -1,6 +1,6 @@
 import { autocomplete, getAlgoliaResults } from '@algolia/autocomplete-js';
 import { createRedirectUrlPlugin } from '@algolia/autocomplete-plugin-redirect-url';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 
 import '@algolia/autocomplete-theme-classic';
 

--- a/examples/redirect-url/package.json
+++ b/examples/redirect-url/package.json
@@ -12,7 +12,7 @@
     "@algolia/autocomplete-js": "1.17.2",
     "@algolia/autocomplete-plugin-redirect-url": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "preact": "10.13.2"
   },
   "devDependencies": {

--- a/examples/reshape/package.json
+++ b/examples/reshape/package.json
@@ -16,7 +16,7 @@
     "@algolia/autocomplete-shared": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
     "@algolia/client-search": "4.16.0",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "preact": "10.13.2",
     "ramda": "0.27.1",
     "search-insights": "2.13.0"

--- a/examples/reshape/searchClient.ts
+++ b/examples/reshape/searchClient.ts
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 
 const appId = 'latency';
 const apiKey = '6be0576ff61c053d5f9a3225e2a90f76';

--- a/examples/slack-with-emojis-and-commands/package.json
+++ b/examples/slack-with-emojis-and-commands/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@algolia/autocomplete-core": "1.17.2",
     "@algolia/autocomplete-preset-algolia": "1.17.2",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "textarea-caret": "3.1.0"

--- a/examples/slack-with-emojis-and-commands/src/Autocomplete.tsx
+++ b/examples/slack-with-emojis-and-commands/src/Autocomplete.tsx
@@ -6,7 +6,7 @@ import {
 } from '@algolia/autocomplete-core';
 import { getAlgoliaResults } from '@algolia/autocomplete-preset-algolia';
 import { Hit } from '@algolia/client-search';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 import React, { useEffect, useRef } from 'react';
 
 import { commands } from './commands';
@@ -151,7 +151,7 @@ export function Autocomplete(
   const activeToken = getActiveToken(state.query, cursorPosition);
   const { top, height } = getCaretCoordinates(inputRef.current);
   const inputProps = autocomplete.getInputProps({
-    inputElement: (inputRef.current as unknown) as HTMLInputElement,
+    inputElement: inputRef.current as unknown as HTMLInputElement,
   });
 
   useEffect(() => {
@@ -217,7 +217,7 @@ export function Autocomplete(
         <div className="box-compose">
           <form
             {...autocomplete.getFormProps({
-              inputElement: (inputRef.current as unknown) as HTMLInputElement,
+              inputElement: inputRef.current as unknown as HTMLInputElement,
             })}
             className="box-form"
           >

--- a/examples/starter-algolia/app.tsx
+++ b/examples/starter-algolia/app.tsx
@@ -2,7 +2,7 @@
 /** @jsx h */
 import { autocomplete, getAlgoliaResults } from '@algolia/autocomplete-js';
 import { Hit } from '@algolia/client-search';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 import { h } from 'preact';
 
 import '@algolia/autocomplete-theme-classic';

--- a/examples/starter-algolia/package.json
+++ b/examples/starter-algolia/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@algolia/autocomplete-js": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "preact": "10.13.2"
   },
   "devDependencies": {

--- a/examples/tags-in-searchbox/app.tsx
+++ b/examples/tags-in-searchbox/app.tsx
@@ -8,7 +8,7 @@ import {
   AutocompleteInsightsApi,
 } from '@algolia/autocomplete-js';
 import { createTagsPlugin, Tag } from '@algolia/autocomplete-plugin-tags';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 import { h, Fragment, render } from 'preact';
 import groupBy from 'ramda/src/groupBy';
 

--- a/examples/tags-in-searchbox/package.json
+++ b/examples/tags-in-searchbox/package.json
@@ -13,7 +13,7 @@
     "@algolia/autocomplete-plugin-tags": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
     "@algolia/client-search": "4.16.0",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "preact": "10.13.2",
     "ramda": "0.27.1",
     "search-insights": "2.13.0"

--- a/examples/tags-with-hits/app.tsx
+++ b/examples/tags-with-hits/app.tsx
@@ -8,7 +8,7 @@ import {
   AutocompleteInsightsApi,
 } from '@algolia/autocomplete-js';
 import { createTagsPlugin, Tag } from '@algolia/autocomplete-plugin-tags';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 import { h, Fragment } from 'preact';
 import groupBy from 'ramda/src/groupBy';
 

--- a/examples/tags-with-hits/package.json
+++ b/examples/tags-with-hits/package.json
@@ -13,7 +13,7 @@
     "@algolia/autocomplete-plugin-tags": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
     "@algolia/client-search": "4.16.0",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "preact": "10.13.2",
     "ramda": "0.27.1",
     "search-insights": "2.13.0"

--- a/examples/twitter-compose-with-typeahead/package.json
+++ b/examples/twitter-compose-with-typeahead/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@algolia/autocomplete-core": "1.17.2",
     "@algolia/autocomplete-preset-algolia": "1.17.2",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "textarea-caret": "3.1.0"

--- a/examples/twitter-compose-with-typeahead/src/Autocomplete.tsx
+++ b/examples/twitter-compose-with-typeahead/src/Autocomplete.tsx
@@ -4,7 +4,7 @@ import {
   parseAlgoliaHitHighlight,
 } from '@algolia/autocomplete-preset-algolia';
 import type { Hit } from '@algolia/client-search';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 import React, { Fragment, useRef } from 'react';
 import getCaretCoordinates from 'textarea-caret';
 
@@ -86,7 +86,7 @@ export function Autocomplete(
     : { top: 0, height: 0 };
 
   const inputProps = autocomplete.getInputProps({
-    inputElement: (inputRef.current as unknown) as HTMLInputElement,
+    inputElement: inputRef.current as unknown as HTMLInputElement,
     autoFocus: true,
     maxLength: 280,
   });
@@ -101,7 +101,7 @@ export function Autocomplete(
           <div className="box-compose">
             <form
               {...autocomplete.getFormProps({
-                inputElement: (inputRef.current as unknown) as HTMLInputElement,
+                inputElement: inputRef.current as unknown as HTMLInputElement,
               })}
             >
               <textarea

--- a/examples/two-column-layout/package.json
+++ b/examples/two-column-layout/package.json
@@ -16,7 +16,7 @@
     "@algolia/autocomplete-shared": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
     "@algolia/client-search": "4.16.0",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "blurhash": "^1.1.5",
     "dequal": "^2.0.3",
     "preact": "10.13.2",

--- a/examples/two-column-layout/src/searchClient.ts
+++ b/examples/two-column-layout/src/searchClient.ts
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 
 export const searchClient = algoliasearch(
   'latency',

--- a/examples/voice-search/app.tsx
+++ b/examples/voice-search/app.tsx
@@ -2,7 +2,7 @@
 /** @jsx h */
 import { autocomplete, getAlgoliaResults } from '@algolia/autocomplete-js';
 import { Hit } from '@algolia/client-search';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 import { h } from 'preact';
 
 import '@algolia/autocomplete-theme-classic';

--- a/examples/voice-search/package.json
+++ b/examples/voice-search/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@algolia/autocomplete-js": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "preact": "10.13.2"
   },
   "devDependencies": {

--- a/examples/vue-instantsearch/package.json
+++ b/examples/vue-instantsearch/package.json
@@ -15,7 +15,7 @@
     "@algolia/autocomplete-plugin-query-suggestions": "1.17.2",
     "@algolia/autocomplete-plugin-recent-searches": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "vue": "3.2.47",
     "vue-instantsearch": "4.8.8"
   },

--- a/examples/vue-instantsearch/src/searchClient.js
+++ b/examples/vue-instantsearch/src/searchClient.js
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 
 export const searchClient = algoliasearch(
   'latency',

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@algolia/autocomplete-js": "1.17.2",
     "@algolia/autocomplete-theme-classic": "1.17.2",
-    "algoliasearch": "4.16.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "vue": "3.2.47"
   },
   "devDependencies": {

--- a/examples/vue/src/App.vue
+++ b/examples/vue/src/App.vue
@@ -7,7 +7,7 @@
 <script lang="jsx">
 import { h, Fragment, render, onMounted } from 'vue';
 import { autocomplete, getAlgoliaResults } from '@algolia/autocomplete-js';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch-v5/lite';
 
 import '@algolia/autocomplete-theme-classic';
 

--- a/packages/autocomplete-plugin-tags/src/createTagsPlugin.tsx
+++ b/packages/autocomplete-plugin-tags/src/createTagsPlugin.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx createElement */
 import { BaseItem, PluginSubscribeParams } from '@algolia/autocomplete-core';
 import {


### PR DESCRIPTION
**Summary**

This PR updates all algoliasearch dependencies in examples to algoliasearch@5.

**TODO**

- [ ] update algoliasearch to ga version and remove alias

FX-2922