### PR TITLE
fix(js): reposition panel above input when it overflows viewport

### DIFF
--- a/packages/autocomplete-js/src/__tests__/positioning.test.ts
+++ b/packages/autocomplete-js/src/__tests__/positioning.test.ts
@@ -206,17 +206,78 @@ describe('Panel positioning', () => {
 
     fireEvent(window, new Event('resize'));
 
-    // panelTop = scrollTop(0) + containerRect.top(1040) - panelTotalHeight(300 + 8 + 0)
-    //          = 732
+    // panelTop = scrollTop(0) + containerRect.top(1040) - panelHeightAbove(300 + 8 * 2)
+    //          = 724
     await waitFor(() => {
       expect(panel).toHaveStyle({
-        top: '732px',
+        top: '724px',
         left: '300px',
         right: '1020px',
       });
     });
 
     (window.getComputedStyle as jest.Mock).mockRestore();
+  });
+
+  test('keeps the panel below the root when its top margin would not fit above', async () => {
+    const container = document.createElement('div');
+    const panelContainer = document.body;
+    document.body.appendChild(container);
+    Object.defineProperty(document.documentElement, 'clientHeight', {
+      configurable: true,
+      value: 328,
+    });
+
+    autocomplete({
+      id: 'autocomplete-0',
+      container,
+      panelContainer,
+      plugins: [querySuggestionsFixturePlugin],
+    });
+
+    const root = document.querySelector<HTMLDivElement>('.aa-Autocomplete')!;
+    root.getBoundingClientRect = jest.fn().mockReturnValue({
+      ...rootPosition,
+      top: 308,
+    });
+    const form = document.querySelector<HTMLFormElement>('.aa-Form')!;
+    form.getBoundingClientRect = jest.fn().mockReturnValue(formPosition);
+    const input = document.querySelector<HTMLInputElement>('.aa-Input')!;
+    userEvent.type(input, 'a');
+
+    const panel = await waitFor(() => getByTestId(panelContainer, 'panel'));
+    Object.defineProperty(panel, 'offsetHeight', {
+      configurable: true,
+      value: 300,
+    });
+
+    const originalGetComputedStyle = window.getComputedStyle;
+    jest.spyOn(window, 'getComputedStyle').mockImplementation((element) => {
+      const style = originalGetComputedStyle(element);
+      if (element === panel) {
+        Object.defineProperties(style, {
+          marginTop: { value: '8px', configurable: true },
+          marginBottom: { value: '0px', configurable: true },
+        });
+      }
+      return style;
+    });
+
+    fireEvent(window, new Event('resize'));
+
+    await waitFor(() => {
+      expect(panel).toHaveStyle({
+        top: '328px',
+        left: '300px',
+        right: '1020px',
+      });
+    });
+
+    (window.getComputedStyle as jest.Mock).mockRestore();
+    Object.defineProperty(document.documentElement, 'clientHeight', {
+      configurable: true,
+      value: 1080,
+    });
   });
 
   test('repositions the panel below the root element after a UI change', async () => {

--- a/packages/autocomplete-js/src/__tests__/positioning.test.ts
+++ b/packages/autocomplete-js/src/__tests__/positioning.test.ts
@@ -163,6 +163,62 @@ describe('Panel positioning', () => {
     fireEvent.scroll(document.body, { target: { scrollTop: 0 } });
   });
 
+  test('positions the panel above the root when it would overflow the viewport', async () => {
+    const container = document.createElement('div');
+    const panelContainer = document.body;
+    document.body.appendChild(container);
+
+    autocomplete({
+      id: 'autocomplete-0',
+      container,
+      panelContainer,
+      plugins: [querySuggestionsFixturePlugin],
+    });
+
+    const root = document.querySelector<HTMLDivElement>('.aa-Autocomplete');
+    root.getBoundingClientRect = jest.fn().mockReturnValue({
+      ...rootPosition,
+      top: 1040,
+    });
+    const form = document.querySelector<HTMLFormElement>('.aa-Form');
+    form.getBoundingClientRect = jest.fn().mockReturnValue(formPosition);
+    const input = document.querySelector<HTMLInputElement>('.aa-Input');
+    userEvent.type(input, 'a');
+
+    const panel = await waitFor(() => getByTestId(panelContainer, 'panel'));
+    Object.defineProperty(panel, 'offsetHeight', {
+      configurable: true,
+      value: 300,
+    });
+
+    // Mock the panel's computed margin to match the default theme (8px top margin)
+    const originalGetComputedStyle = window.getComputedStyle;
+    jest.spyOn(window, 'getComputedStyle').mockImplementation((element) => {
+      const style = originalGetComputedStyle(element);
+      if (element === panel) {
+        Object.defineProperties(style, {
+          marginTop: { value: '8px', configurable: true },
+          marginBottom: { value: '0px', configurable: true },
+        });
+      }
+      return style;
+    });
+
+    fireEvent(window, new Event('resize'));
+
+    // panelTop = scrollTop(0) + containerRect.top(1040) - panelTotalHeight(300 + 8 + 0)
+    //          = 732
+    await waitFor(() => {
+      expect(panel).toHaveStyle({
+        top: '732px',
+        left: '300px',
+        right: '1020px',
+      });
+    });
+
+    (window.getComputedStyle as jest.Mock).mockRestore();
+  });
+
   test('repositions the panel below the root element after a UI change', async () => {
     const container = document.createElement('div');
     const panelContainer = document.body;

--- a/packages/autocomplete-js/src/autocomplete.ts
+++ b/packages/autocomplete-js/src/autocomplete.ts
@@ -144,6 +144,7 @@ export function autocomplete<TItem extends BaseItem>(
             panelPlacement: props.value.renderer.panelPlacement,
             container: dom.value.root,
             form: dom.value.form,
+            panel: dom.value.panel,
             environment: props.value.core.environment,
           }),
     });
@@ -176,6 +177,7 @@ export function autocomplete<TItem extends BaseItem>(
 
     renderSearchBox(renderProps);
     renderPanel(render, renderProps);
+    requestAnimationFrame(setPanelPosition);
   }
 
   runEffect(() => {

--- a/packages/autocomplete-js/src/getPanelPlacementStyle.ts
+++ b/packages/autocomplete-js/src/getPanelPlacementStyle.ts
@@ -25,21 +25,26 @@ export function getPanelPlacementStyle({
     environment.document.body.scrollTop ||
     0;
   const panelHeight = panel.offsetHeight;
-  const panelStyle = environment.getComputedStyle(panel);
+  const panelStyle =
+    'getComputedStyle' in environment &&
+    typeof environment.getComputedStyle === 'function'
+      ? environment.getComputedStyle(panel)
+      : panel.style;
   const panelMarginTop = parseFloat(panelStyle.marginTop) || 0;
   const panelMarginBottom = parseFloat(panelStyle.marginBottom) || 0;
-  const panelTotalHeight = panelHeight + panelMarginTop + panelMarginBottom;
+  const panelHeightWithMargins =
+    panelHeight + panelMarginTop + panelMarginBottom;
+  const panelHeightAbove = panelHeight + panelMarginTop * 2;
   const top = scrollTop + containerRect.top + containerRect.height;
-  const panelTop =
-    scrollTop + containerRect.top - panelTotalHeight;
+  const panelTop = scrollTop + containerRect.top - panelHeightAbove;
   const bottomSpace =
     environment.document.documentElement.clientHeight -
     (containerRect.top + containerRect.height);
   const topSpace = containerRect.top;
   const shouldPlacePanelAbove =
-    panelTotalHeight > 0 &&
-    bottomSpace < panelTotalHeight &&
-    topSpace >= panelTotalHeight;
+    panelHeightWithMargins > 0 &&
+    bottomSpace < panelHeightWithMargins &&
+    topSpace >= panelHeightAbove;
   const verticalPosition = shouldPlacePanelAbove ? panelTop : top;
 
   switch (panelPlacement) {

--- a/packages/autocomplete-js/src/getPanelPlacementStyle.ts
+++ b/packages/autocomplete-js/src/getPanelPlacementStyle.ts
@@ -6,12 +6,14 @@ type GetPanelPlacementStyleParams = Pick<
 > & {
   container: HTMLElement;
   form: HTMLElement;
+  panel: HTMLElement;
 };
 
 export function getPanelPlacementStyle({
   panelPlacement,
   container,
   form,
+  panel,
   environment,
 }: GetPanelPlacementStyleParams) {
   const containerRect = container.getBoundingClientRect();
@@ -22,19 +24,35 @@ export function getPanelPlacementStyle({
     environment.document.documentElement.scrollTop ||
     environment.document.body.scrollTop ||
     0;
+  const panelHeight = panel.offsetHeight;
+  const panelStyle = environment.getComputedStyle(panel);
+  const panelMarginTop = parseFloat(panelStyle.marginTop) || 0;
+  const panelMarginBottom = parseFloat(panelStyle.marginBottom) || 0;
+  const panelTotalHeight = panelHeight + panelMarginTop + panelMarginBottom;
   const top = scrollTop + containerRect.top + containerRect.height;
+  const panelTop =
+    scrollTop + containerRect.top - panelTotalHeight;
+  const bottomSpace =
+    environment.document.documentElement.clientHeight -
+    (containerRect.top + containerRect.height);
+  const topSpace = containerRect.top;
+  const shouldPlacePanelAbove =
+    panelTotalHeight > 0 &&
+    bottomSpace < panelTotalHeight &&
+    topSpace >= panelTotalHeight;
+  const verticalPosition = shouldPlacePanelAbove ? panelTop : top;
 
   switch (panelPlacement) {
     case 'start': {
       return {
-        top,
+        top: verticalPosition,
         left: containerRect.left,
       };
     }
 
     case 'end': {
       return {
-        top,
+        top: verticalPosition,
         right:
           environment.document.documentElement.clientWidth -
           (containerRect.left + containerRect.width),
@@ -43,7 +61,7 @@ export function getPanelPlacementStyle({
 
     case 'full-width': {
       return {
-        top,
+        top: verticalPosition,
         left: 0,
         right: 0,
         width: 'unset',
@@ -55,7 +73,7 @@ export function getPanelPlacementStyle({
       const formRect = form.getBoundingClientRect();
 
       return {
-        top,
+        top: verticalPosition,
         left: formRect.left,
         right:
           environment.document.documentElement.clientWidth -


### PR DESCRIPTION
## Description

Fixes #1335

When the autocomplete input is positioned near the bottom of the viewport, the autocomplete panel renders below the input and extends beyond the visible area, making most of the suggestions invisible to the user.

This PR dynamically measures the rendered panel's height and repositions it **above** the input when there isn't enough space below and there is enough space above.

### Before (bug)

```
    ┌─────────────────────┐
    │  Autocomplete Input  │
    └─────────────────────┘
    ┌─────────────────────┐
    │  Panel               │
    │                      │
    │  ── viewport edge ── │  ← cut off here
    │  (invisible)         │
    └─────────────────────┘
```

### After (fix)

```
    ┌─────────────────────┐
    │  Panel               │
    │                      │
    └─────────────────────┘
    ┌─────────────────────┐
    │  Autocomplete Input  │
    └─────────────────────┘
    ── viewport edge ──
```

## Changes

### 1. `packages/autocomplete-js/src/autocomplete.ts`

**Passed the `panel` element to `getPanelPlacementStyle()`** so that the panel's actual height can be measured during positioning:

```diff
         panelPlacement: props.value.renderer.panelPlacement,
         container: dom.value.root,
         form: dom.value.form,
+        panel: dom.value.panel,
         environment: props.value.core.environment,
```

**Added `requestAnimationFrame(setPanelPosition)` after `renderPanel()`** to schedule the position calculation for the next animation frame, after the panel has been rendered and its layout dimensions are available:

```diff
     renderSearchBox(renderProps);
     renderPanel(render, renderProps);
+    requestAnimationFrame(setPanelPosition);
```

This is consistent with how `requestAnimationFrame` is already used elsewhere in the codebase (e.g., the `resize` handler).

### 2. `packages/autocomplete-js/src/getPanelPlacementStyle.ts`

**Added `panel` to the function parameters** and implemented the viewport overflow detection:

```diff
+  const panelHeight = panel.offsetHeight;
   const top = scrollTop + containerRect.top + containerRect.height;
+  const panelTop = scrollTop + containerRect.top - panelHeight;
+  const bottomSpace =
+    environment.document.documentElement.clientHeight -
+    (containerRect.top + containerRect.height);
+  const topSpace = containerRect.top;
+  const shouldPlacePanelAbove =
+    panelHeight > 0 && bottomSpace < panelHeight && topSpace >= panelHeight;
+  const verticalPosition = shouldPlacePanelAbove ? panelTop : top;
```

The logic:
- `panelHeight > 0` — only consider flipping when the panel has been rendered and has a measurable height
- `bottomSpace < panelHeight` — the panel would overflow below the viewport
- `topSpace >= panelHeight` — there is enough space above the input to fit the panel

The panel flips above **only** when both conditions are met. If neither direction has enough space, it defaults to below (preserving existing behavior).

`offsetHeight` provides the rendered layout height of the panel, which is sufficient for determining whether the panel will fit below the input.

The calculated `verticalPosition` replaces the hardcoded `top` in all four `panelPlacement` cases (`start`, `end`, `full-width`, `input-wrapper-width`).

### 3. `packages/autocomplete-js/src/__tests__/positioning.test.ts`

**Added a regression test** that:
1. Places the autocomplete root near the bottom of the viewport (`top: 1040` in a `1080px` viewport)
2. Renders the panel with a height of `300px`
3. Triggers a resize event to recalculate positioning
4. Asserts the panel is positioned at `top: 740px` (above the input: `1040 - 300 = 740`) instead of `1060px` (below the input, which would overflow)

## Design decisions

- **No new configuration option**: The flip behavior is automatic and only activates when the panel would actually overflow. Existing behavior is preserved in all other cases.
- **No horizontal flipping**: This PR only addresses vertical overflow, which is the behavior described in the issue.

## Reproduction

From #1335:
1. Open [this CodeSandbox](https://codesandbox.io/p/sandbox/github/algolia/autocomplete/tree/next/examples/query-suggestions-with-inline-categories)
2. Resize the window so the preview is about 860×430px
3. Focus the autocomplete input
4. **Before**: Panel is cut off below the viewport
5. **After**: Panel flips above the input
